### PR TITLE
Quantify gas cost of liquidity check (`refactor/user-markets`)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
+via-ir = true
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/test/TestGas.sol
+++ b/test/TestGas.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {IPoolAddressesProvider} from "src/interfaces/Interfaces.sol";
+
+import "src/MorphoInternal.sol";
+
+import {Test} from "@forge-std/Test.sol";
+
+contract TestGas is Test, MorphoInternal {
+    using MarketLib for Types.Market;
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using ThreeHeapOrdering for ThreeHeapOrdering.HeapArray;
+
+    address constant aave = 0x63a72806098Bd3D9520cC43356dD78afe5D386D9;
+    address constant dai = 0xd586E7F844cEa2F87f50152665BCbc2C279D8d70;
+    address constant usdc = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
+    address constant usdt = 0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7;
+    address constant wbtc = 0x50b7545627a5162F82A992c33b87aDc75187B218;
+    address constant weth = 0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB;
+    address constant wavax = 0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7;
+
+    address constant aAave = 0xf329e36C7bF6E5E86ce2150875a84Ce77f477375;
+    address constant aDai = 0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE;
+    address constant aUsdc = 0x625E7708f30cA75bfd92586e17077590C60eb4cD;
+    address constant aUsdt = 0x6ab707Aca953eDAeFBc4fD23bA73294241490620;
+    address constant aWbtc = 0x078f358208685046a11C85e8ad32895DED33A249;
+    address constant aWeth = 0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8;
+    address constant avWavax = 0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97;
+
+    address constant rewardToken = wavax;
+
+    address constant stableDebtDai = 0xd94112B5B62d53C9402e7A60289c6810dEF1dC9B;
+    address constant variableDebtDai = 0x8619d80FB0141ba7F184CbF22fd724116D9f7ffC;
+    address constant variableDebtUsdc = 0xFCCf3cAbbe80101232d343252614b6A3eE81C989;
+
+    address constant poolDataProviderAddress = 0x69FA688f1Dc47d4B5d8029D5a35FB7a548310654;
+    address constant poolAddressesProviderAddress = 0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb;
+    address constant rewardsControllerAddress = 0x929EC64c34a17401F460460D4B9390518E5B473e;
+
+    address internal constant user = address(0xDeaD);
+
+    function setUp() public virtual {
+        _addressesProvider = IPoolAddressesProvider(poolAddressesProviderAddress);
+        _pool = IPool(_addressesProvider.getPool());
+        _maxSortedUsers = 16;
+
+        createMarket(dai);
+        createMarket(weth);
+        createMarket(wbtc);
+        createMarket(usdc);
+        createMarket(usdt);
+        createMarket(aave);
+    }
+
+    function createMarket(address underlyingToken) internal {
+        DataTypes.ReserveData memory reserveData = _pool.getReserveData(underlyingToken);
+
+        address poolToken = reserveData.aTokenAddress;
+        Types.Market storage market = _market[poolToken];
+
+        market.setIndexes(
+            _pool.getReserveNormalizedIncome(underlyingToken),
+            _pool.getReserveNormalizedVariableDebt(underlyingToken),
+            WadRayMath.RAY,
+            WadRayMath.RAY
+        );
+        market.lastUpdateTimestamp = uint32(block.timestamp);
+
+        market.underlying = underlyingToken;
+        market.variableDebtToken = reserveData.variableDebtTokenAddress;
+        market.reserveFactor = 0;
+        market.p2pIndexCursor = 5000;
+
+        _marketsCreated.push(poolToken);
+    }
+
+    function supply(address poolToken, uint256 onPool, uint256 inP2P) internal {
+        EnumerableSet.AddressSet storage set = _userCollaterals[user];
+        set.add(poolToken);
+
+        _updateSupplierInDS(poolToken, user, onPool, inP2P);
+    }
+
+    function collat(address poolToken, uint256 amount) internal {
+        EnumerableSet.AddressSet storage set = _userCollaterals[user];
+        set.add(poolToken);
+
+        _marketBalances[poolToken].collateral[user] = amount;
+    }
+
+    function borrow(address poolToken, uint256 onPool, uint256 inP2P) internal {
+        EnumerableSet.AddressSet storage set = _userBorrows[user];
+        set.add(poolToken);
+
+        _updateBorrowerInDS(poolToken, user, onPool, inP2P);
+    }
+}

--- a/test/TestRef.t.sol
+++ b/test/TestRef.t.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import {TestGas} from "./TestGas.sol";
+
+contract TestRef is TestGas {
+    function test() public view {
+        _liquidityData(user, aDai, 0, 0);
+    }
+}

--- a/test/TestShortAll.t.sol
+++ b/test/TestShortAll.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "./TestGas.sol";
+
+contract TestShortAll is TestGas {
+    function setUp() public override {
+        super.setUp();
+
+        supply(aDai, 0.5e18, 0.5e18);
+        supply(aUsdt, 0.5e8, 0.5e8);
+        supply(aUsdc, 0.5e6, 0.5e6);
+
+        borrow(aAave, 0.25e18, 0.25e18);
+        borrow(aWeth, 0.25e18, 0.25e18);
+        borrow(aWbtc, 0.25e8, 0.25e8);
+    }
+
+    function test() public view {
+        _liquidityData(user, aDai, 0, 0.5e18);
+    }
+}

--- a/test/TestSingleCollateral.t.sol
+++ b/test/TestSingleCollateral.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "./TestGas.sol";
+
+contract TestSingleCollateral is TestGas {
+    function setUp() public override {
+        super.setUp();
+
+        collat(aDai, 1 ether);
+    }
+
+    function test() public view {
+        _liquidityData(user, aDai, 0, 0);
+    }
+}

--- a/test/TestSingleSupply.t.sol
+++ b/test/TestSingleSupply.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "./TestGas.sol";
+
+contract TestSingleSupply is TestGas {
+    function setUp() public override {
+        super.setUp();
+
+        supply(aDai, 0.5 ether, 0.5 ether);
+    }
+
+    function test() public view {
+        _liquidityData(user, aDai, 0, 0);
+    }
+}

--- a/test/TestSupplyBorrowAllMarkets.t.sol
+++ b/test/TestSupplyBorrowAllMarkets.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "./TestGas.sol";
+
+contract TestSupplyBorrowAllMarkets is TestGas {
+    function setUp() public override {
+        super.setUp();
+
+        supply(aDai, 0.5e18, 0.5e18);
+        borrow(aDai, 0.25e18, 0.25e18);
+
+        supply(aAave, 0.5e18, 0.5e18);
+        borrow(aAave, 0.25e18, 0.25e18);
+
+        supply(aWeth, 0.5e18, 0.5e18);
+        borrow(aWeth, 0.25e18, 0.25e18);
+
+        supply(aWbtc, 0.5e8, 0.5e8);
+        borrow(aWbtc, 0.25e8, 0.25e8);
+
+        supply(aUsdt, 0.5e8, 0.5e8);
+        borrow(aUsdt, 0.25e8, 0.25e8);
+
+        supply(aUsdc, 0.5e6, 0.5e6);
+        borrow(aUsdc, 0.25e6, 0.25e6);
+    }
+
+    function test() public view {
+        _liquidityData(user, aDai, 0, 0);
+    }
+}

--- a/test/TestSupplyBorrowSingleMarket.t.sol
+++ b/test/TestSupplyBorrowSingleMarket.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "./TestGas.sol";
+
+contract TestSupplyBorrowSingleMarket is TestGas {
+    function setUp() public override {
+        super.setUp();
+
+        supply(aDai, 0.5 ether, 0.5 ether);
+        borrow(aDai, 0.25 ether, 0.25 ether);
+    }
+
+    function test() public view {
+        _liquidityData(user, aDai, 0, 0);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request quantifies the gas consumption of the changes introduced in #31 

I tested 5 things:
1. reference test for base gas consumption, for a non-user
2. gas consumption when supplying on a single market
3. gas consumption when supplying all USD-pegged markets & borrowing all non-USD-pegged cryptos
4. gas consumption when supplying & borrowing on a single market
5. gas consumption when supplying & borrowing on all created markets

Here are the results, compared to https://github.com/morpho-dao/morpho-aave-v3/pull/43:

| Test                         | `main` | `refactor/user-markets` |
|------------------------------|--------|-------------------------|
| TestRef                      | 54067  | 25796                   |
| TestSingleSupply             | 118932 | 91740                   |
| TestShortAll                 | 465470 | 443578                  |
| TestSupplyBorrowSingleMarket | 133365 | 121678                  |
| TestSupplyBorrowAllMarkets   | 517260 | 588987                  |