### PR TITLE
Move increaseP2PDeltas to PositionsManager

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -167,6 +167,12 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
         }
     }
 
+    function increaseP2PDeltas(address underlying, uint256 amount) external onlyOwner isMarketCreated(underlying) {
+        _positionsManager.functionDelegateCall(
+            abi.encodeWithSelector(IPositionsManager.increaseP2PDeltasLogic.selector, underlying, amount)
+        );
+    }
+
     /// INTERNAL ///
 
     function _supply(address underlying, uint256 amount, address from, address onBehalf, uint256 maxLoops)

--- a/src/MorphoInternal.sol
+++ b/src/MorphoInternal.sol
@@ -90,41 +90,6 @@ abstract contract MorphoInternal is MorphoStorage {
         emit Events.MarketCreated(underlying, reserveFactor, p2pIndexCursor);
     }
 
-    function _increaseP2PDeltas(address underlying, uint256 amount) internal {
-        Types.Indexes256 memory indexes = _updateIndexes(underlying);
-
-        Types.Market storage market = _market[underlying];
-        Types.Deltas memory deltas = market.deltas;
-        uint256 poolSupplyIndex = indexes.supply.poolIndex;
-        uint256 poolBorrowIndex = indexes.borrow.poolIndex;
-
-        amount = Math.min(
-            amount,
-            Math.min(
-                deltas.p2pSupplyAmount.rayMul(indexes.supply.p2pIndex).zeroFloorSub(
-                    deltas.p2pSupplyDelta.rayMul(poolSupplyIndex)
-                ),
-                deltas.p2pBorrowAmount.rayMul(indexes.borrow.p2pIndex).zeroFloorSub(
-                    deltas.p2pBorrowDelta.rayMul(poolBorrowIndex)
-                )
-            )
-        );
-        if (amount == 0) revert Errors.AmountIsZero();
-
-        uint256 newP2PSupplyDelta = deltas.p2pSupplyDelta + amount.rayDiv(poolSupplyIndex);
-        uint256 newP2PBorrowDelta = deltas.p2pBorrowDelta + amount.rayDiv(poolBorrowIndex);
-
-        market.deltas.p2pSupplyDelta = newP2PSupplyDelta;
-        market.deltas.p2pBorrowDelta = newP2PBorrowDelta;
-        emit Events.P2PSupplyDeltaUpdated(underlying, newP2PSupplyDelta);
-        emit Events.P2PBorrowDeltaUpdated(underlying, newP2PBorrowDelta);
-
-        _POOL.borrowFromPool(underlying, amount);
-        _POOL.supplyToPool(underlying, amount);
-
-        emit Events.P2PDeltasIncreased(underlying, amount);
-    }
-
     function _approveManager(address owner, address manager, bool isAllowed) internal {
         _isManaging[owner][manager] = isAllowed;
         emit Events.ManagerApproval(owner, manager, isAllowed);

--- a/src/MorphoSetters.sol
+++ b/src/MorphoSetters.sol
@@ -52,10 +52,6 @@ abstract contract MorphoSetters is IMorphoSetters, MorphoInternal {
         _createMarket(underlying, reserveFactor, p2pIndexCursor);
     }
 
-    function increaseP2PDeltas(address underlying, uint256 amount) external onlyOwner isMarketCreated(underlying) {
-        _increaseP2PDeltas(underlying, amount);
-    }
-
     function setMaxSortedUsers(uint256 newMaxSortedUsers) external onlyOwner {
         if (newMaxSortedUsers == 0) revert Errors.MaxSortedUsersCannotBeZero();
         _maxSortedUsers = newMaxSortedUsers;

--- a/src/PositionsManager.sol
+++ b/src/PositionsManager.sol
@@ -202,4 +202,8 @@ contract PositionsManager is IPositionsManager, PositionsManagerInternal {
             );
         return (vars.amountToLiquidate, vars.amountToSeize);
     }
+
+    function increaseP2PDeltasLogic(address underlying, uint256 amount) external {
+        _increaseP2PDeltas(underlying, amount);
+    }
 }

--- a/src/interfaces/IPositionsManager.sol
+++ b/src/interfaces/IPositionsManager.sol
@@ -32,4 +32,6 @@ interface IPositionsManager {
         address borrower,
         address liquidator
     ) external returns (uint256 liquidated, uint256 seized);
+
+    function increaseP2PDeltasLogic(address underlying, uint256 amount) external;
 }


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request showcases something we've missed: by adding the entrypoint `increaseP2PDetlas` to `Morpho`, we are duplicating bytecode between `Morpho` & `PositionsManager`
For example, the logic contained inside `_updateIndexes` would be duplicated both in `Morpho` and in `PositionsManager`

This is illustrated in this PR, by moving `increaseP2PDeltas` to the `PositionsManager`, delegate called by `Morpho`, and the following bytecode size diff:

| Contract | `Morpho` | `PositionsManager` |
|----------|----------|--------------------|
| Before   | 19.34    | 22.25              |
| After    | 18.688   | 22.481             |

We're thus saving ~650kb on Morpho & losing ~230kb on the PositionsManager

However, for this PR to be complete, we should move the `_computeIndexes` logic to `PositionsManagerInternal` and avoid mixing internal functions between implementations for the reason showcased here: perhaps was it not a good choice to have all internal functions shared by implementations

But we may want to expose indexes getter on `Morpho`, which would require the `_computeIndexes` logic (in parts, at least), so it may not be worth it

This PR is a showcase to gather your POV