### PR TITLE
Use permit2's solmate instead of root solmate

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -15,6 +15,6 @@ test/=test/
 @aave-v3-periphery/=lib/aave-v3-periphery/contracts/
 
 @solmate/=lib/solmate/src/
-solmate/=lib/solmate/
+solmate/=lib/permit2/lib/solmate/
 
 @permit2/=lib/permit2/src/

--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -12,6 +12,7 @@ import {Constants} from "./libraries/Constants.sol";
 
 import {DelegateCall} from "@morpho-utils/DelegateCall.sol";
 import {Permit2Lib} from "@permit2/libraries/Permit2Lib.sol";
+import {ERC20 as Permit2ERC20} from "solmate/src/tokens/ERC20.sol";
 import {ERC20, SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
 
 import {MorphoStorage} from "./MorphoStorage.sol";
@@ -23,9 +24,9 @@ import {MorphoSetters} from "./MorphoSetters.sol";
 /// @custom:contact security@morpho.xyz
 /// @notice The main Morpho contract exposing all user entry points.
 contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
-    using Permit2Lib for ERC20;
     using DelegateCall for address;
     using SafeTransferLib for ERC20;
+    using Permit2Lib for Permit2ERC20;
 
     /// CONSTRUCTOR ///
 
@@ -87,7 +88,7 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
         uint256 deadline,
         Types.Signature calldata signature
     ) external returns (uint256) {
-        ERC20(underlying).simplePermit2(
+        Permit2ERC20(underlying).simplePermit2(
             msg.sender, address(this), amount, deadline, signature.v, signature.r, signature.s
         );
         return _supply(underlying, amount, msg.sender, onBehalf, maxIterations);
@@ -118,7 +119,7 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
         uint256 deadline,
         Types.Signature calldata signature
     ) external returns (uint256) {
-        ERC20(underlying).simplePermit2(
+        Permit2ERC20(underlying).simplePermit2(
             msg.sender, address(this), amount, deadline, signature.v, signature.r, signature.s
         );
         return _supplyCollateral(underlying, amount, msg.sender, onBehalf);
@@ -163,7 +164,7 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
         uint256 deadline,
         Types.Signature calldata signature
     ) external returns (uint256) {
-        ERC20(underlying).simplePermit2(
+        Permit2ERC20(underlying).simplePermit2(
             msg.sender, address(this), amount, deadline, signature.v, signature.r, signature.s
         );
         return _repay(underlying, amount, msg.sender, onBehalf);

--- a/src/PositionsManager.sol
+++ b/src/PositionsManager.sol
@@ -13,6 +13,7 @@ import {Math} from "@morpho-utils/math/Math.sol";
 import {PercentageMath} from "@morpho-utils/math/PercentageMath.sol";
 
 import {Permit2Lib} from "@permit2/libraries/Permit2Lib.sol";
+import {ERC20 as Permit2ERC20} from "solmate/src/tokens/ERC20.sol";
 import {ERC20, SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
@@ -21,8 +22,8 @@ import {PositionsManagerInternal} from "./PositionsManagerInternal.sol";
 
 contract PositionsManager is IPositionsManager, PositionsManagerInternal {
     using PoolLib for IPool;
-    using Permit2Lib for ERC20;
     using SafeTransferLib for ERC20;
+    using Permit2Lib for Permit2ERC20;
     using EnumerableSet for EnumerableSet.AddressSet;
     using MarketBalanceLib for Types.MarketBalances;
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -51,7 +52,7 @@ contract PositionsManager is IPositionsManager, PositionsManagerInternal {
 
         Types.Indexes256 memory indexes = _updateIndexes(underlying);
 
-        ERC20(underlying).transferFrom2(from, address(this), amount);
+        Permit2ERC20(underlying).transferFrom2(from, address(this), amount);
 
         Types.SupplyRepayVars memory vars = _executeSupply(underlying, amount, from, onBehalf, maxIterations, indexes);
 
@@ -76,7 +77,7 @@ contract PositionsManager is IPositionsManager, PositionsManagerInternal {
 
         Types.Indexes256 memory indexes = _updateIndexes(underlying);
 
-        ERC20(underlying).transferFrom2(from, address(this), amount);
+        Permit2ERC20(underlying).transferFrom2(from, address(this), amount);
 
         _executeSupplyCollateral(underlying, amount, from, onBehalf, indexes.supply.poolIndex);
 
@@ -130,7 +131,7 @@ contract PositionsManager is IPositionsManager, PositionsManagerInternal {
 
         if (amount == 0) return 0;
 
-        ERC20(underlying).transferFrom2(repayer, address(this), amount);
+        Permit2ERC20(underlying).transferFrom2(repayer, address(this), amount);
 
         Types.SupplyRepayVars memory vars =
             _executeRepay(underlying, amount, repayer, onBehalf, _defaultMaxIterations.repay, indexes);
@@ -232,7 +233,7 @@ contract PositionsManager is IPositionsManager, PositionsManagerInternal {
 
         if (amount == 0) return (0, 0);
 
-        ERC20(underlyingBorrowed).transferFrom2(liquidator, address(this), amount);
+        Permit2ERC20(underlyingBorrowed).transferFrom2(liquidator, address(this), amount);
 
         Types.SupplyRepayVars memory repayVars =
             _executeRepay(underlyingBorrowed, amount, liquidator, borrower, 0, borrowIndexes);


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request changes imports so that we do rely on solmate's version `Permit2Lib` was written with and expected to be used with.

In this specific case, I would understand that it is not important because we're only overloading interfaces and thus it has no impact on the final behavior of the code.

Beware though, that introducing incoherent remappings such as `solmate/=lib/solmate/` may break the assumption that "the dependency was audited so it's safer to rely on the audited code" because of incompatible dependency versions...
