### PR TITLE
Rename isManaging to isManagedBy

### DIFF
--- a/src/MorphoGetters.sol
+++ b/src/MorphoGetters.sol
@@ -111,8 +111,8 @@ abstract contract MorphoGetters is IMorphoGetters, MorphoInternal {
     }
 
     /// @notice Returns whether `manager` is a manager of `delegator`.
-    function isManaging(address delegator, address manager) external view returns (bool) {
-        return _isManaging[delegator][manager];
+    function isManagedBy(address delegator, address manager) external view returns (bool) {
+        return _isManagedBy[delegator][manager];
     }
 
     /// @notice Returns the nonce of `user` for the manager approval signature.

--- a/src/MorphoInternal.sol
+++ b/src/MorphoInternal.sol
@@ -174,7 +174,7 @@ abstract contract MorphoInternal is MorphoStorage {
     /// @param manager The address of the manager.
     /// @param isAllowed Whether `manager` is allowed to manage `delegator`'s position or not.
     function _approveManager(address delegator, address manager, bool isAllowed) internal {
-        _isManaging[delegator][manager] = isAllowed;
+        _isManagedBy[delegator][manager] = isAllowed;
         emit Events.ManagerApproval(delegator, manager, isAllowed);
     }
 

--- a/src/MorphoStorage.sol
+++ b/src/MorphoStorage.sol
@@ -43,8 +43,8 @@ abstract contract MorphoStorage is Initializable, Ownable2StepUpgradeable {
     /// @dev The borrow markets entered by users.
     mapping(address => EnumerableSet.AddressSet) internal _userBorrows;
 
-    /// @dev Users allowances to manage other users' accounts. delegator => manager => isManaging
-    mapping(address => mapping(address => bool)) internal _isManaging;
+    /// @dev Users allowances to manage other users' accounts. delegator => manager => isManagedBy
+    mapping(address => mapping(address => bool)) internal _isManagedBy;
 
     /// @dev The nonce of users. Used to prevent replay attacks with EIP-712 signatures.
     mapping(address => uint256) internal _userNonce;

--- a/src/PositionsManagerInternal.sol
+++ b/src/PositionsManagerInternal.sol
@@ -50,7 +50,7 @@ abstract contract PositionsManagerInternal is MatchingEngine {
 
     /// @dev Validates the manager's permission.
     function _validatePermission(address delegator, address manager) internal view {
-        if (!(delegator == manager || _isManaging[delegator][manager])) revert Errors.PermissionDenied();
+        if (!(delegator == manager || _isManagedBy[delegator][manager])) revert Errors.PermissionDenied();
     }
 
     /// @dev Validates the input.

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -25,7 +25,7 @@ interface IMorphoGetters {
     function userCollaterals(address user) external view returns (address[] memory);
     function userBorrows(address user) external view returns (address[] memory);
 
-    function isManaging(address delegator, address manager) external view returns (bool);
+    function isManagedBy(address delegator, address manager) external view returns (bool);
     function userNonce(address user) external view returns (uint256);
 
     function defaultIterations() external view returns (Types.Iterations memory);

--- a/test/integration/TestIntegrationApproval.sol
+++ b/test/integration/TestIntegrationApproval.sol
@@ -33,7 +33,7 @@ contract TestIntegrationApproval is IntegrationTest {
 
         vm.prank(delegator);
         morpho.approveManager(manager, isAllowed);
-        assertEq(morpho.isManaging(delegator, manager), isAllowed);
+        assertEq(morpho.isManagedBy(delegator, manager), isAllowed);
     }
 
     function testApproveManagerWithSig(uint128 deadline) public {
@@ -64,7 +64,7 @@ contract TestIntegrationApproval is IntegrationTest {
             sig
         );
 
-        assertEq(morpho.isManaging(DELEGATOR, MANAGER), true);
+        assertEq(morpho.isManagedBy(DELEGATOR, MANAGER), true);
         assertEq(morpho.userNonce(DELEGATOR), 1);
     }
 

--- a/test/integration/TestIntegrationUpgrade.sol
+++ b/test/integration/TestIntegrationUpgrade.sol
@@ -13,7 +13,7 @@ contract TestIntegrationUpgrade is IntegrationTest {
     UserMock internal borrower1;
     UserMock internal borrower2;
 
-    // Excludes isManaging, userNonce
+    // Excludes isManagedBy, userNonce
     struct UserStorageToCheck {
         uint256 scaledPoolSupplyBalance;
         uint256 scaledPoolBorrowBalance;

--- a/test/internal/TestInternalMorphoInternal.sol
+++ b/test/internal/TestInternalMorphoInternal.sol
@@ -631,7 +631,7 @@ contract TestInternalMorphoInternal is InternalTest {
 
     function testApproveManager(address owner, address manager, bool isAllowed) public {
         _approveManager(owner, manager, isAllowed);
-        assertEq(_isManaging[owner][manager], isAllowed);
+        assertEq(_isManagedBy[owner][manager], isAllowed);
     }
 
     function increaseP2PDeltasTest(address underlying, uint256 amount) external {

--- a/test/invariant/TestInvariantApproveManager.sol
+++ b/test/invariant/TestInvariantApproveManager.sol
@@ -35,7 +35,7 @@ contract TestInvariantApproveManager is InvariantTest {
                 for (uint256 k; k < senders.length; ++k) {
                     address delegator = senders[k];
 
-                    if (delegator == manager || morpho.isManaging(delegator, manager)) continue;
+                    if (delegator == manager || morpho.isManagedBy(delegator, manager)) continue;
 
                     vm.startPrank(manager);
                     vm.expectRevert(Errors.PermissionDenied.selector);


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request:

- fixes #678 

The PR literally took a single Ctrl+Maj+H (~30s)
The rationale is that `isManaging` suggests the order of parameters is: 1. manager, 2. delegator ; whereas in practice it is the other way around

Another way could be to only update the storage variable and switch the order of parameters of the getter