### PR TITLE
Add order of magnitude assertions

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -20,7 +20,7 @@ on:
       integration-fuzz-runs:
         description: The number of fuzz rounds to perform for each fuzzing unit test.
         required: false
-        default: 32
+        default: 128
         type: number
       invariant-runs:
         description: The number of runs to perform for invariant tests.

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ libs = ["node_modules", "lib"]
 fs_permissions = [{ access = "read", path = "./config/"}]
 
 [fuzz]
-runs = 8
+runs = 16
 
 [invariant]
 runs = 4

--- a/test/helpers/BaseTest.sol
+++ b/test/helpers/BaseTest.sol
@@ -26,8 +26,15 @@ contract BaseTest is Test {
     uint256 private constant MAX_AMOUNT = 1e20 ether;
 
     /// @dev Asserts a is approximately equal to b, with a maximum absolute difference of DUST_THRESHOLD.
-    function assertApproxEqDust(uint256 a, uint256 b, string memory err) internal {
+    ///      Should be commonly used to assert a ~= b, modulo roundings (e.g. scaled balances).
+    function assertApproxEq(uint256 a, uint256 b, string memory err) internal {
         assertApproxEqAbs(a, b, Constants.DUST_THRESHOLD, err);
+    }
+
+    /// @dev Asserts a is approximately equal to b, with a maximum absolute difference of 10 * DUST_THRESHOLD.
+    ///      Should be commonly used to assert a ~= b, modulo the maximum order of magnitude of roundings (10).
+    function assertApproxEqDust(uint256 a, uint256 b, string memory err) internal {
+        assertApproxEqAbs(a, b, Constants.DUST_THRESHOLD * 10, err);
     }
 
     /// @dev Asserts a is approximately less than or equal to b, with a maximum absolute difference of maxDelta.

--- a/test/integration/TestIntegrationBorrow.sol
+++ b/test/integration/TestIntegrationBorrow.sol
@@ -37,16 +37,16 @@ contract TestIntegrationBorrow is IntegrationTest {
         // Assert balances on Morpho.
         assertEq(test.borrowed, amount, "borrowed != amount");
         assertEq(test.scaledP2PBorrow, 0, "scaledP2PBorrow != 0");
-        assertApproxEqDust(poolBorrow, amount, "poolBorrow != amount");
+        assertApproxEq(poolBorrow, amount, "poolBorrow != amount");
 
         assertEq(test.collaterals.length, 0, "collaterals.length");
         assertEq(test.borrows.length, 1, "borrows.length");
         assertEq(test.borrows[0], market.underlying, "borrows[0]");
 
-        assertApproxEqDust(morpho.borrowBalance(market.underlying, onBehalf), amount, "borrow != amount");
+        assertApproxEq(morpho.borrowBalance(market.underlying, onBehalf), amount, "borrow != amount");
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), amount, 2, "morphoVariableBorrow != amount");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), amount, "morphoVariableBorrow != amount");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert receiver's underlying balance.
@@ -77,7 +77,7 @@ contract TestIntegrationBorrow is IntegrationTest {
         // Assert balances on Morpho.
         assertEq(test.borrowed, amount, "borrowed != amount");
         assertEq(test.scaledPoolBorrow, 0, "scaledPoolBorrow != 0");
-        assertApproxEqDust(p2pBorrow, amount, "p2pBorrow != amount");
+        assertApproxEq(p2pBorrow, amount, "p2pBorrow != amount");
         assertApproxLeAbs(
             morpho.scaledP2PSupplyBalance(market.underlying, address(promoter1)),
             test.scaledP2PBorrow,
@@ -92,13 +92,13 @@ contract TestIntegrationBorrow is IntegrationTest {
         assertEq(test.borrows.length, 1, "borrows.length");
         assertEq(test.borrows[0], market.underlying, "borrows[0]");
 
-        assertApproxEqDust(morpho.borrowBalance(market.underlying, onBehalf), amount, "borrow != amount");
-        assertApproxEqAbs(
-            morpho.supplyBalance(market.underlying, address(promoter1)), amount, 2, "promoterSupply != amount"
+        assertApproxEq(morpho.borrowBalance(market.underlying, onBehalf), amount, "borrow != amount");
+        assertApproxEqDust(
+            morpho.supplyBalance(market.underlying, address(promoter1)), amount, "promoterSupply != amount"
         );
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 2, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert receiver's underlying balance.
@@ -109,11 +109,10 @@ contract TestIntegrationBorrow is IntegrationTest {
         );
 
         // Assert Morpho's market state.
-        assertApproxEqAbs(test.morphoMarket.deltas.supply.scaledDelta, 0, 1, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(
+        assertApproxEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
+        assertApproxEq(
             test.morphoMarket.deltas.supply.scaledP2PTotal,
             test.scaledP2PBorrow,
-            1,
             "scaledTotalSupplyP2P != scaledP2PBorrow"
         );
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
@@ -306,16 +305,14 @@ contract TestIntegrationBorrow is IntegrationTest {
         test = _assertBorrowPool(market, amount, onBehalf, receiver, test);
 
         // Assert Morpho's market state.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.supply.scaledDelta.rayMul(test.indexes.supply.poolIndex),
             supplyDelta,
-            1,
             "supplyDelta != expectedSupplyDelta"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.supply.scaledP2PTotal.rayMul(test.indexes.supply.p2pIndex),
             supplyDelta,
-            1,
             "totalSupplyP2P != expectedSupplyDelta"
         );
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
@@ -353,15 +350,14 @@ contract TestIntegrationBorrow is IntegrationTest {
 
         // Assert Morpho's market state.
         assertEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.supply.scaledP2PTotal.rayMul(test.indexes.supply.p2pIndex),
             idleSupply,
-            1,
             "totalSupplyP2P != expectedIdleSupply"
         );
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
         assertEq(test.morphoMarket.deltas.borrow.scaledP2PTotal, 0, "scaledTotalBorrowP2P != 0");
-        assertApproxEqDust(test.morphoMarket.idleSupply, idleSupply, "idleSupply != expectedIdleSupply");
+        assertApproxEq(test.morphoMarket.idleSupply, idleSupply, "idleSupply != expectedIdleSupply");
     }
 
     function testShouldNotBorrowWhenBorrowCapExceeded(

--- a/test/integration/TestIntegrationFee.sol
+++ b/test/integration/TestIntegrationFee.sol
@@ -47,7 +47,7 @@ contract TestIntegrationFee is IntegrationTest {
         user.approve(market.underlying, type(uint256).max);
         user.repay(market.underlying, type(uint256).max);
 
-        assertApproxEqAbs(ERC20(market.underlying).balanceOf(address(morpho)), balanceBefore, 1, "Fee collected != 0");
+        assertApproxEq(ERC20(market.underlying).balanceOf(address(morpho)), balanceBefore, "Fee collected != 0");
     }
 
     function testRepayFeeWithP2PWithoutDelta(uint256 seed, uint16 reserveFactor, uint256 amount) public {
@@ -83,10 +83,9 @@ contract TestIntegrationFee is IntegrationTest {
 
         user.repay(market.underlying, type(uint256).max);
 
-        assertApproxEqAbs(
+        assertApproxEqDust(
             ERC20(testMarket.underlying).balanceOf(address(morpho)),
             balanceBefore + expectedFeeCollected,
-            2,
             "Right amount of fees collected"
         );
     }
@@ -130,10 +129,9 @@ contract TestIntegrationFee is IntegrationTest {
         user.approve(testMarket.underlying, type(uint256).max);
         user.repay(testMarket.underlying, type(uint256).max);
 
-        assertApproxEqAbs(
+        assertApproxEqDust(
             ERC20(testMarket.underlying).balanceOf(address(morpho)),
             balanceBefore + expectedFeeCollected,
-            3,
             "Wrong amount of fees"
         );
     }

--- a/test/integration/TestIntegrationLiquidate.sol
+++ b/test/integration/TestIntegrationLiquidate.sol
@@ -426,16 +426,14 @@ contract TestIntegrationLiquidate is IntegrationTest {
             "repaid > borrowed * closeFactor"
         );
 
-        assertApproxEqAbs(
+        assertApproxEqDust(
             morpho.borrowBalance(borrowedMarket.underlying, borrower) + test.repaid,
             test.borrowedBalanceBefore,
-            2,
             "borrowBalanceAfter != borrowedBalanceBefore - repaid"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             morpho.collateralBalance(collateralMarket.underlying, borrower) + test.seized,
             test.collateralBalanceBefore,
-            1,
             "collateralBalanceAfter != collateralBalanceBefore - seized"
         );
     }
@@ -453,16 +451,14 @@ contract TestIntegrationLiquidate is IntegrationTest {
             "repaid > borrowed * closeFactor"
         );
 
-        assertApproxEqAbs(
+        assertApproxEqDust(
             morpho.borrowBalance(borrowedMarket.underlying, borrower) + test.repaid,
             test.borrowedBalanceBefore,
-            2,
             "borrowBalanceAfter != borrowedBalanceBefore - repaid"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             morpho.collateralBalance(collateralMarket.underlying, borrower) + test.seized,
             test.collateralBalanceBefore,
-            1,
             "collateralBalanceAfter != collateralBalanceBefore - seized"
         );
 

--- a/test/integration/TestIntegrationPermit2.sol
+++ b/test/integration/TestIntegrationPermit2.sol
@@ -75,8 +75,8 @@ contract TestIntegrationPermit2 is IntegrationTest {
         vm.prank(delegator);
         morpho.supplyWithPermit(market.underlying, amount, delegator, DEFAULT_MAX_ITERATIONS, deadline, sig);
         /// The maximum gap needs to be 4 because sometimes the timestamp is very big, otherwise the test reverts.
-        assertApproxEqAbs(
-            morpho.supplyBalance(market.underlying, delegator), balanceSupplyBefore + amount, 4, "Incorrect Supply"
+        assertApproxEqDust(
+            morpho.supplyBalance(market.underlying, delegator), balanceSupplyBefore + amount, "Incorrect Supply"
         );
         assertEq(ERC20(market.underlying).balanceOf(delegator), balanceBefore - amount, "Incorrect Balance");
     }
@@ -116,10 +116,9 @@ contract TestIntegrationPermit2 is IntegrationTest {
 
         vm.prank(delegator);
         morpho.supplyCollateralWithPermit(market.underlying, amount, onBehalf, deadline, sig);
-        assertApproxEqAbs(
+        assertApproxEqDust(
             morpho.collateralBalance(market.underlying, onBehalf),
             balanceSupplyBefore + amount,
-            3,
             "Incorrect Supply Collateral"
         );
 
@@ -164,7 +163,7 @@ contract TestIntegrationPermit2 is IntegrationTest {
         vm.prank(delegator);
         morpho.repayWithPermit(market.underlying, amount, onBehalf, deadline, sig);
 
-        assertApproxEqAbs(morpho.borrowBalance(market.underlying, onBehalf), 0, 1, "Incorrect Borrow Balance");
+        assertApproxEqDust(morpho.borrowBalance(market.underlying, onBehalf), 0, "Incorrect Borrow Balance");
         assertEq(ERC20(market.underlying).balanceOf(delegator), balanceBefore - amount, "Incorrect Balance");
     }
 

--- a/test/integration/TestIntegrationPoolLib.sol
+++ b/test/integration/TestIntegrationPoolLib.sol
@@ -38,7 +38,7 @@ contract TestIntegrationPoolLibSupply is TestIntegrationPoolLib {
         pool.supplyToPool(dai, amount, pool.getReserveNormalizedIncome(dai));
 
         assertEq(ERC20(dai).balanceOf(address(this)) + amount, balanceBefore, "balance");
-        assertApproxEqAbs(ERC20(aDai).balanceOf(address(this)), aBalanceBefore + amount, 1, "aBalance");
+        assertApproxEq(ERC20(aDai).balanceOf(address(this)), aBalanceBefore + amount, "aBalance");
     }
 }
 
@@ -59,7 +59,7 @@ contract TestIntegrationPoolLibBorrow is TestIntegrationPoolLib {
         pool.borrowFromPool(dai, amount / 2);
 
         assertEq(ERC20(dai).balanceOf(address(this)), balanceBefore + amount / 2, "balance");
-        assertApproxEqAbs(ERC20(vDai).balanceOf(address(this)), vBalanceBefore + amount / 2, 1, "vBalance");
+        assertApproxEq(ERC20(vDai).balanceOf(address(this)), vBalanceBefore + amount / 2, "vBalance");
     }
 }
 
@@ -83,7 +83,7 @@ contract TestIntegrationPoolLibRepay is TestIntegrationPoolLib {
         pool.repayToPool(dai, vDai, amount / 4);
 
         assertEq(ERC20(dai).balanceOf(address(this)) + amount / 4, balanceBefore, "balance");
-        assertApproxEqAbs(ERC20(vDai).balanceOf(address(this)) + amount / 4, vBalanceBefore, 1, "vBalance");
+        assertApproxEq(ERC20(vDai).balanceOf(address(this)) + amount / 4, vBalanceBefore, "vBalance");
     }
 }
 
@@ -103,6 +103,6 @@ contract TestIntegrationPoolLibWithdraw is TestIntegrationPoolLib {
         pool.withdrawFromPool(dai, aDai, amount / 2);
 
         assertEq(ERC20(dai).balanceOf(address(this)), balanceBefore + amount / 2, "balance");
-        assertApproxEqAbs(ERC20(aDai).balanceOf(address(this)) + amount / 2, aBalanceBefore, 1, "aBalance");
+        assertApproxEq(ERC20(aDai).balanceOf(address(this)) + amount / 2, aBalanceBefore, "aBalance");
     }
 }

--- a/test/integration/TestIntegrationRepay.sol
+++ b/test/integration/TestIntegrationRepay.sol
@@ -57,26 +57,26 @@ contract TestIntegrationRepay is IntegrationTest {
         // Assert balances on Morpho.
         assertGe(poolBorrow, 0, "poolBorrow == 0");
         assertLe(poolBorrow, remaining, "poolBorrow > remaining");
-        assertApproxEqDust(test.repaid, amount, "repaid != amount");
-        assertApproxEqDust(p2pBorrow, promoted, "p2pBorrow != promoted");
+        assertApproxEq(test.repaid, amount, "repaid != amount");
+        assertApproxEq(p2pBorrow, promoted, "p2pBorrow != promoted");
 
         assertEq(test.collaterals.length, 0, "collaterals.length");
         assertEq(test.borrows.length, 1, "borrows.length");
         assertEq(test.borrows[0], market.underlying, "borrows[0]");
 
         // Assert Morpho getters.
-        assertApproxEqDust(morpho.borrowBalance(market.underlying, onBehalf), remaining, "borrow != remaining");
+        assertApproxEq(morpho.borrowBalance(market.underlying, onBehalf), remaining, "borrow != remaining");
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
-            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 1, "morphoSupply != morphoSupplyBefore"
+        assertApproxEqDust(
+            market.supplyOf(address(morpho)), test.morphoSupplyBefore, "morphoSupply != morphoSupplyBefore"
         );
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 1, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert user's underlying balance.
-        assertApproxEqAbs(
-            test.balanceBefore - user.balanceOf(market.underlying), amount, 1, "balanceBefore - balanceAfter != amount"
+        assertApproxEqDust(
+            test.balanceBefore - user.balanceOf(market.underlying), amount, "balanceBefore - balanceAfter != amount"
         );
 
         // Assert Morpho's market state.
@@ -134,7 +134,7 @@ contract TestIntegrationRepay is IntegrationTest {
         // Assert balances on Morpho.
         assertEq(test.scaledP2PBorrow, 0, "scaledP2PBorrow != 0");
         assertEq(test.scaledPoolBorrow, 0, "scaledPoolBorrow != 0");
-        assertApproxEqAbs(test.repaid, test.borrowed, 2, "repaid != amount");
+        assertApproxEqDust(test.repaid, test.borrowed, "repaid != amount");
         assertEq(
             morpho.scaledP2PSupplyBalance(market.underlying, address(promoter1)), 0, "promoterScaledP2PSupply != 0"
         );
@@ -144,18 +144,17 @@ contract TestIntegrationRepay is IntegrationTest {
 
         // Assert Morpho getters.
         assertEq(morpho.borrowBalance(market.underlying, onBehalf), 0, "borrow != 0");
-        assertApproxEqDust(
+        assertApproxEq(
             morpho.supplyBalance(market.underlying, address(promoter1)), promoted, "promoterSupply != promoted"
         );
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             market.supplyOf(address(morpho)),
             test.morphoSupplyBefore + promoted,
-            3,
             "morphoSupply != morphoSupplyBefore + promoted"
         );
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 2, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert user's underlying balance.
@@ -167,7 +166,7 @@ contract TestIntegrationRepay is IntegrationTest {
         );
 
         // Assert Morpho's market state.
-        assertApproxEqAbs(test.morphoMarket.deltas.supply.scaledDelta, 0, 2, "scaledSupplyDelta != 0");
+        assertApproxEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
         assertEq(test.morphoMarket.deltas.supply.scaledP2PTotal, 0, "scaledTotalSupplyP2P != 0");
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
         assertEq(test.morphoMarket.deltas.borrow.scaledP2PTotal, 0, "scaledTotalBorrowP2P != 0");
@@ -222,47 +221,46 @@ contract TestIntegrationRepay is IntegrationTest {
         // Assert balances on Morpho.
         assertEq(test.scaledP2PBorrow, 0, "scaledP2PBorrow != 0");
         assertEq(test.scaledPoolBorrow, 0, "scaledPoolBorrow != 0");
-        assertApproxEqDust(test.repaid, test.borrowed, "repaid != amount");
+        assertApproxEq(test.repaid, test.borrowed, "repaid != amount");
 
         assertEq(test.collaterals.length, 0, "collaterals.length");
         assertEq(test.borrows.length, 0, "borrows.length");
 
         // Assert Morpho getters.
         assertEq(morpho.borrowBalance(market.underlying, onBehalf), 0, "borrow != 0");
-        assertApproxEqAbs(
-            morpho.supplyBalance(market.underlying, address(promoter1)), test.borrowed, 2, "promoterSupply != borrowed"
+        assertApproxEqDust(
+            morpho.supplyBalance(market.underlying, address(promoter1)), test.borrowed, "promoterSupply != borrowed"
         );
 
         // Assert Morpho's position on pool.
-        assertApproxGeAbs(
+        assertApproxEqDust(
             market.supplyOf(address(morpho)),
             test.morphoSupplyBefore + supplyGapBefore,
-            1,
             "morphoSupply != morphoSupplyBefore + supplyGapBefore"
         );
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 1, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
-        assertEq(_supplyGap(market), 0, "supplyGapAfter != 0");
+        assertApproxEqDust(_supplyGap(market), 0, "supplyGapAfter != 0");
 
         // Assert user's underlying balance.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.balanceBefore,
             user.balanceOf(market.underlying) + test.repaid,
-            1,
             "balanceBefore != balanceAfter + repaid"
         );
 
+        uint256 expectedIdleSupply = test.borrowed - supplyGapBefore;
+
         // Assert Morpho's market state.
-        assertApproxEqAbs(test.morphoMarket.deltas.supply.scaledDelta, 0, 1, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(
+        assertApproxEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
+        assertApproxEqDust(
             test.morphoMarket.deltas.supply.scaledP2PTotal.rayMul(test.indexes.supply.p2pIndex),
-            test.borrowed,
-            1,
-            "scaledTotalSupplyP2P != borrowed"
+            expectedIdleSupply,
+            "totalSupplyP2P != expectedIdleSupply"
         );
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
         assertEq(test.morphoMarket.deltas.borrow.scaledP2PTotal, 0, "scaledTotalBorrowP2P != 0");
-        assertApproxEqAbs(test.morphoMarket.idleSupply, test.borrowed, 1, "idleSupply != borrowed");
+        assertApproxEq(test.morphoMarket.idleSupply, expectedIdleSupply, "idleSupply != expectedIdleSupply");
     }
 
     function testShouldRepayAllP2PBorrowWhenDemotedZero(uint256 seed, uint256 amount, address onBehalf) public {
@@ -317,37 +315,34 @@ contract TestIntegrationRepay is IntegrationTest {
 
         // Assert Morpho getters.
         assertEq(morpho.borrowBalance(market.underlying, onBehalf), 0, "borrow != 0");
-        assertApproxEqAbs(
-            morpho.supplyBalance(market.underlying, address(promoter1)), test.borrowed, 2, "promoterSupply != borrowed"
+        assertApproxEqDust(
+            morpho.supplyBalance(market.underlying, address(promoter1)), test.borrowed, "promoterSupply != borrowed"
         );
 
         // Assert Morpho's position on pool.
         uint256 morphoSupply = market.supplyOf(address(morpho));
-        assertApproxEqAbs(
-            morphoSupply, test.morphoSupplyBefore + test.borrowed, 2, "morphoSupply != morphoSupplyBefore + borrowed"
+        assertApproxEqDust(
+            morphoSupply, test.morphoSupplyBefore + test.borrowed, "morphoSupply != morphoSupplyBefore + borrowed"
         );
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 1, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert user's underlying balance.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.balanceBefore,
             user.balanceOf(market.underlying) + test.repaid,
-            1,
             "balanceBefore != balanceAfter + repaid"
         );
 
         // Assert Morpho's market state.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.supply.scaledDelta.rayMul(test.indexes.supply.poolIndex),
             test.borrowed,
-            1,
             "supplyDelta != borrowed"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.supply.scaledP2PTotal.rayMul(test.indexes.supply.p2pIndex),
             test.borrowed,
-            1,
             "totalSupplyP2P != borrowed"
         );
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");

--- a/test/integration/TestIntegrationSupply.sol
+++ b/test/integration/TestIntegrationSupply.sol
@@ -38,26 +38,25 @@ contract TestIntegrationSupply is IntegrationTest {
         assertEq(test.supplied, amount, "supplied != amount");
         assertEq(test.scaledP2PSupply, 0, "scaledP2PSupply != 0");
         assertEq(test.scaledCollateral, 0, "scaledCollateral != 0");
-        assertApproxEqDust(poolSupply, amount, "poolSupply != amount");
+        assertApproxEq(poolSupply, amount, "poolSupply != amount");
 
         assertEq(test.collaterals.length, 0, "collaterals.length");
         assertEq(test.borrows.length, 0, "borrows.length");
 
-        assertApproxEqDust(morpho.supplyBalance(market.underlying, onBehalf), amount, "totalSupply != amount");
+        assertApproxEq(morpho.supplyBalance(market.underlying, onBehalf), amount, "totalSupply != amount");
         assertEq(morpho.collateralBalance(market.underlying, onBehalf), 0, "collateral != 0");
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             market.supplyOf(address(morpho)),
             test.morphoSupplyBefore + amount,
-            1,
             "morphoSupply != morphoSupplyBefore + amount"
         );
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert user's underlying balance.
-        assertApproxEqAbs(
-            test.balanceBefore - user.balanceOf(market.underlying), amount, 1, "balanceBefore - balanceAfter != amount"
+        assertApproxEqDust(
+            test.balanceBefore - user.balanceOf(market.underlying), amount, "balanceBefore - balanceAfter != amount"
         );
 
         return test;
@@ -78,52 +77,47 @@ contract TestIntegrationSupply is IntegrationTest {
         // Assert balances on Morpho.
         assertEq(test.supplied, amount, "supplied != amount");
         assertEq(test.scaledCollateral, 0, "scaledCollateral != 0");
-        assertApproxEqDust(test.scaledPoolSupply, 0, "scaledPoolSupply != 0");
-        assertApproxEqDust(p2pSupply, amount, "p2pSupply != amount");
-        assertApproxEqAbs(
+        assertApproxEq(test.scaledPoolSupply, 0, "scaledPoolSupply != 0");
+        assertApproxEq(p2pSupply, amount, "p2pSupply != amount");
+        assertApproxEq(
             morpho.scaledP2PBorrowBalance(market.underlying, address(promoter1)),
             test.scaledP2PSupply,
-            1,
             "promoterScaledP2PBorrow != scaledP2PSupply"
         );
-        assertApproxEqDust(
+        assertApproxEq(
             morpho.scaledPoolBorrowBalance(market.underlying, address(promoter1)), 0, "promoterScaledPoolBorrow != 0"
         );
 
         assertEq(test.collaterals.length, 0, "collaterals.length");
         assertEq(test.borrows.length, 0, "borrows.length");
 
-        assertApproxEqAbs(morpho.supplyBalance(market.underlying, onBehalf), amount, 2, "supply != amount");
+        assertApproxEqDust(morpho.supplyBalance(market.underlying, onBehalf), amount, "supply != amount");
         assertEq(morpho.collateralBalance(market.underlying, onBehalf), 0, "collateral != 0");
-        assertApproxEqDust(
-            morpho.borrowBalance(market.underlying, address(promoter1)), amount, "promoterBorrow != amount"
-        );
+        assertApproxEq(morpho.borrowBalance(market.underlying, address(promoter1)), amount, "promoterBorrow != amount");
 
         // Assert Morpho's position on pool.
         assertApproxGeAbs(
             market.supplyOf(address(morpho)), test.morphoSupplyBefore, 2, "morphoSupplyAfter != morphoSupplyBefore"
         );
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 1, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert user's underlying balance.
-        assertApproxEqAbs(
-            test.balanceBefore - user.balanceOf(market.underlying), amount, 1, "balanceBefore - balanceAfter != amount"
+        assertApproxEqDust(
+            test.balanceBefore - user.balanceOf(market.underlying), amount, "balanceBefore - balanceAfter != amount"
         );
 
         // Assert Morpho's market state.
         assertEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(
+        assertApproxEq(
             test.morphoMarket.deltas.supply.scaledP2PTotal,
             test.scaledP2PSupply,
-            1,
             "scaledTotalSupplyP2P != scaledP2PSupply"
         );
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
-        assertApproxEqAbs(
+        assertApproxEq(
             test.morphoMarket.deltas.borrow.scaledP2PTotal,
             test.scaledP2PSupply,
-            1,
             "scaledTotalBorrowP2P != scaledP2PSupply"
         );
         assertEq(test.morphoMarket.idleSupply, 0, "idleSupply != 0");
@@ -212,7 +206,7 @@ contract TestIntegrationSupply is IntegrationTest {
 
         test = _assertSupplyPool(market, amount, onBehalf, test);
 
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), amount, 1, "morphoVariableBorrow != amount");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), amount, "morphoVariableBorrow != amount");
 
         _assertMarketAccountingZero(test.morphoMarket);
     }
@@ -276,17 +270,15 @@ contract TestIntegrationSupply is IntegrationTest {
 
         // Assert Morpho's market state.
         assertEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(test.morphoMarket.deltas.supply.scaledP2PTotal, 0, 1, "scaledTotalSupplyP2P != 0");
-        assertApproxEqAbs(
+        assertApproxEq(test.morphoMarket.deltas.supply.scaledP2PTotal, 0, "scaledTotalSupplyP2P != 0");
+        assertApproxEqDust(
             test.morphoMarket.deltas.borrow.scaledDelta.rayMul(test.indexes.borrow.poolIndex),
             borrowDelta,
-            2,
             "borrowDelta != expectedBorrowDelta"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.borrow.scaledP2PTotal.rayMul(test.indexes.borrow.p2pIndex),
             borrowDelta,
-            1,
             "totalBorrowP2P != expectedBorrowDelta"
         );
         assertEq(test.morphoMarket.idleSupply, 0, "idleSupply != 0");

--- a/test/integration/TestIntegrationSupplyCollateral.sol
+++ b/test/integration/TestIntegrationSupplyCollateral.sol
@@ -52,7 +52,7 @@ contract TestIntegrationSupplyCollateral is IntegrationTest {
         assertEq(test.scaledP2PSupply, 0, "scaledP2PSupply != 0");
         assertEq(test.scaledPoolSupply, 0, "scaledPoolSupply != 0");
         assertEq(test.supplied, amount, "supplied != amount");
-        assertApproxEqAbs(collateral, amount, 1, "collateral != amount");
+        assertApproxEq(collateral, amount, "collateral != amount");
 
         assertEq(test.collaterals.length, 1, "collaterals.length");
         assertEq(test.collaterals[0], market.underlying, "collaterals[0]");
@@ -62,10 +62,9 @@ contract TestIntegrationSupplyCollateral is IntegrationTest {
         assertApproxLeAbs(morpho.collateralBalance(market.underlying, onBehalf), amount, 1, "collateral != amount");
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             market.supplyOf(address(morpho)),
             test.morphoSupplyBefore + amount,
-            1,
             "morphoSupply != morphoSupplyBefore + amount"
         );
         assertEq(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");

--- a/test/integration/TestIntegrationWETHGateway.sol
+++ b/test/integration/TestIntegrationWETHGateway.sol
@@ -72,7 +72,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
         if (onBehalf != address(this)) assertEq(onBehalf.balance, onBehalfBalanceBefore, "onBehalfBalance");
         assertEq(address(this).balance + amount, balanceBefore, "balanceAfter != balanceBefore - amount");
         assertEq(supplied, amount, "supplied != amount");
-        assertApproxEqAbs(morpho.supplyBalance(weth, onBehalf), amount, 1, "supplyBalance != amount");
+        assertApproxEqDust(morpho.supplyBalance(weth, onBehalf), amount, "supplyBalance != amount");
     }
 
     function testCannotSupplyCollateralETHWhenAmountIsZero(address onBehalf) public {
@@ -96,7 +96,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
         if (onBehalf != address(this)) assertEq(onBehalf.balance, onBehalfBalanceBefore, "onBehalfBalance");
         assertEq(supplied, amount, "supplied != amount");
         assertEq(address(this).balance + amount, balanceBefore, "balanceAfter != balanceBefore - amount");
-        assertApproxEqAbs(morpho.collateralBalance(weth, onBehalf), amount, 2, "collateralBalance != amount");
+        assertApproxEqDust(morpho.collateralBalance(weth, onBehalf), amount, "collateralBalance != amount");
     }
 
     function testCannotWithdrawIfWETHGatewayNotManager(uint256 amount) public {
@@ -132,14 +132,13 @@ contract TestIntegrationWETHGateway is IntegrationTest {
         uint256 withdrawn = wethGateway.withdrawETH(toWithdraw, receiver, DEFAULT_MAX_ITERATIONS);
 
         if (receiver != address(this)) assertEq(address(this).balance, balanceBefore, "balanceAfter != balanceBefore");
-        assertApproxEqAbs(withdrawn, Math.min(toWithdraw, supply), 1, "withdrawn != minimum");
-        assertApproxEqAbs(
-            morpho.supplyBalance(weth, address(this)), supply - withdrawn, 2, "supplyBalance != supply - toWithdraw"
+        assertApproxEqDust(withdrawn, Math.min(toWithdraw, supply), "withdrawn != minimum");
+        assertApproxEqDust(
+            morpho.supplyBalance(weth, address(this)), supply - withdrawn, "supplyBalance != supply - toWithdraw"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             receiver.balance,
             receiverBalanceBefore + withdrawn,
-            1,
             "receiverBalanceAfter != receiverBalanceBefore + withdrawn"
         );
     }
@@ -177,17 +176,15 @@ contract TestIntegrationWETHGateway is IntegrationTest {
         uint256 withdrawn = wethGateway.withdrawCollateralETH(toWithdraw, receiver);
 
         if (receiver != address(this)) assertEq(address(this).balance, balanceBefore, "balanceAfter != balanceBefore");
-        assertApproxEqAbs(withdrawn, Math.min(toWithdraw, collateral), 1, "withdrawn != minimum");
-        assertApproxEqAbs(
+        assertApproxEqDust(withdrawn, Math.min(toWithdraw, collateral), "withdrawn != minimum");
+        assertApproxEqDust(
             morpho.collateralBalance(weth, address(this)),
             collateral - withdrawn,
-            2,
             "collateralBalance != collateral - toWithdraw"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             receiver.balance,
             receiverBalanceBefore + withdrawn,
-            1,
             "receiverBalanceAfter != receiverBalanceBefore + withdrawn"
         );
     }
@@ -225,7 +222,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
 
         assertEq(borrowed, toBorrow, "borrowed != toBorrow");
         assertGt(morpho.borrowBalance(weth, address(this)), 0);
-        assertApproxEqAbs(morpho.borrowBalance(weth, address(this)), toBorrow, 1);
+        assertApproxEqDust(morpho.borrowBalance(weth, address(this)), toBorrow, "toBorrow");
         assertEq(receiver.balance, balanceBefore + toBorrow, "balance != expectedBalance");
     }
 
@@ -253,9 +250,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
 
         assertEq(repaid, toRepay);
         assertEq(repayer.balance, 0);
-        assertApproxEqAbs(
-            morpho.borrowBalance(weth, address(this)), toBorrow - toRepay, 2, "borrow balance != expected"
-        );
+        assertApproxEqDust(morpho.borrowBalance(weth, address(this)), toBorrow - toRepay, "borrow balance != expected");
     }
 
     function testRepayETHWithExcess(uint256 amount, uint256 toRepay, address onBehalf, address repayer) public {
@@ -279,7 +274,7 @@ contract TestIntegrationWETHGateway is IntegrationTest {
 
         assertEq(repaid, borrowBalance);
         assertEq(repayer.balance, toRepay - borrowBalance);
-        assertApproxEqAbs(morpho.borrowBalance(weth, address(this)), 0, 2, "borrow balance != 0");
+        assertApproxEqDust(morpho.borrowBalance(weth, address(this)), 0, "borrow balance != 0");
     }
 
     function _supplyETH(address onBehalf, uint256 amount) internal returns (uint256) {

--- a/test/integration/TestIntegrationWithdraw.sol
+++ b/test/integration/TestIntegrationWithdraw.sol
@@ -70,17 +70,16 @@ contract TestIntegrationWithdraw is IntegrationTest {
         assertEq(morpho.collateralBalance(market.underlying, onBehalf), 0, "collateral != 0");
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
-            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 1, "morphoSupply != morphoSupplyBefore"
+        assertApproxEqDust(
+            market.supplyOf(address(morpho)), test.morphoSupplyBefore, "morphoSupply != morphoSupplyBefore"
         );
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 2, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert receiver's underlying balance.
-        assertApproxEqAbs(
+        assertApproxEqDust(
             ERC20(market.underlying).balanceOf(receiver),
             test.balanceBefore + amount,
-            1,
             "balanceAfter - balanceBefore != amount"
         );
 
@@ -146,9 +145,9 @@ contract TestIntegrationWithdraw is IntegrationTest {
         assertEq(test.scaledP2PSupply, 0, "scaledP2PSupply != 0");
         assertEq(test.scaledPoolSupply, 0, "scaledPoolSupply != 0");
         assertEq(test.scaledCollateral, 0, "scaledCollateral != 0");
-        assertApproxEqAbs(test.withdrawn, test.supplied, 3, "withdrawn != supplied");
-        assertApproxEqAbs(
-            morpho.scaledP2PBorrowBalance(market.underlying, address(promoter1)), 0, 2, "promoterScaledP2PBorrow != 0"
+        assertApproxEqDust(test.withdrawn, test.supplied, "withdrawn != supplied");
+        assertApproxEqDust(
+            morpho.scaledP2PBorrowBalance(market.underlying, address(promoter1)), 0, "promoterScaledP2PBorrow != 0"
         );
 
         assertEq(test.collaterals.length, 0, "collaterals.length");
@@ -157,15 +156,15 @@ contract TestIntegrationWithdraw is IntegrationTest {
         // Assert Morpho getters.
         assertEq(morpho.supplyBalance(market.underlying, onBehalf), 0, "supply != 0");
         assertEq(morpho.collateralBalance(market.underlying, onBehalf), 0, "collateral != 0");
-        assertApproxEqAbs(
-            morpho.borrowBalance(market.underlying, address(promoter1)), promoted, 3, "promoterBorrow != promoted"
+        assertApproxEqDust(
+            morpho.borrowBalance(market.underlying, address(promoter1)), promoted, "promoterBorrow != promoted"
         );
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
-            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 2, "morphoSupply != morphoSupplyBefore"
+        assertApproxEqDust(
+            market.supplyOf(address(morpho)), test.morphoSupplyBefore, "morphoSupply != morphoSupplyBefore"
         );
-        assertApproxEqAbs(market.variableBorrowOf(address(morpho)), promoted, 2, "morphoVariableBorrow != promoted");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), promoted, "morphoVariableBorrow != promoted");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert receiver's underlying balance.
@@ -178,9 +177,9 @@ contract TestIntegrationWithdraw is IntegrationTest {
 
         // Assert Morpho's market state.
         assertEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(test.morphoMarket.deltas.supply.scaledP2PTotal, 0, 2, "scaledTotalSupplyP2P != 0");
+        assertApproxEqDust(test.morphoMarket.deltas.supply.scaledP2PTotal, 0, "scaledTotalSupplyP2P != 0");
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
-        assertApproxEqAbs(test.morphoMarket.deltas.borrow.scaledP2PTotal, 0, 2, "scaledTotalBorrowP2P != 0");
+        assertApproxEqDust(test.morphoMarket.deltas.borrow.scaledP2PTotal, 0, "scaledTotalBorrowP2P != 0");
         assertEq(test.morphoMarket.idleSupply, 0, "idleSupply != 0");
     }
 
@@ -251,44 +250,41 @@ contract TestIntegrationWithdraw is IntegrationTest {
         // Assert Morpho getters.
         assertEq(morpho.supplyBalance(market.underlying, onBehalf), 0, "supply != 0");
         assertEq(morpho.collateralBalance(market.underlying, onBehalf), 0, "collateral != 0");
-        assertApproxEqAbs(
-            morpho.borrowBalance(market.underlying, address(promoter1)), test.supplied, 1, "promoter1Borrow != supplied"
+        assertApproxEqDust(
+            morpho.borrowBalance(market.underlying, address(promoter1)), test.supplied, "promoter1Borrow != supplied"
         );
-        assertApproxLeAbs(
-            morpho.supplyBalance(market.underlying, address(promoter2)), test.supplied, 2, "promoter2Supply != supplied"
+        assertApproxEqDust(
+            morpho.supplyBalance(market.underlying, address(promoter2)), test.supplied, "promoter2Supply != supplied"
         );
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
-            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 1, "morphoSupply != morphoSupplyBefore"
+        assertApproxEqDust(
+            market.supplyOf(address(morpho)), test.morphoSupplyBefore, "morphoSupply != morphoSupplyBefore"
         );
-        assertApproxGeAbs(market.variableBorrowOf(address(morpho)), 0, 2, "morphoVariableBorrow != 0");
+        assertApproxEqDust(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert user's underlying balance.
-        assertApproxLeAbs(
+        assertApproxEqDust(
             ERC20(market.underlying).balanceOf(receiver),
             test.balanceBefore + test.withdrawn,
-            2,
             "balanceAfter != balanceBefore + withdrawn"
         );
 
         // Assert Morpho's market state.
         assertEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.supply.scaledP2PTotal.rayMul(test.indexes.supply.p2pIndex),
             test.supplied,
-            1,
             "totalSupplyP2P != supplied"
         );
         assertEq(test.morphoMarket.deltas.borrow.scaledDelta, 0, "scaledBorrowDelta != 0");
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.borrow.scaledP2PTotal.rayMul(test.indexes.borrow.p2pIndex),
             test.supplied,
-            2,
             "totalBorrowP2P != supplied"
         );
-        assertApproxEqAbs(test.morphoMarket.idleSupply, 0, 2, "idleSupply != 0");
+        assertApproxEqDust(test.morphoMarket.idleSupply, 0, "idleSupply != 0");
     }
 
     function testShouldWithdrawAllP2PSupplyWhenDemotedZero(
@@ -352,16 +348,16 @@ contract TestIntegrationWithdraw is IntegrationTest {
         // Assert Morpho getters.
         assertEq(morpho.supplyBalance(market.underlying, onBehalf), 0, "supply != 0");
         assertEq(morpho.collateralBalance(market.underlying, onBehalf), 0, "collateral != 0");
-        assertApproxEqAbs(
-            morpho.borrowBalance(market.underlying, address(promoter1)), test.supplied, 1, "promoter1Borrow != supplied"
+        assertApproxEqDust(
+            morpho.borrowBalance(market.underlying, address(promoter1)), test.supplied, "promoter1Borrow != supplied"
         );
 
         // Assert Morpho's position on pool.
         uint256 morphoVariableBorrow = market.variableBorrowOf(address(morpho));
-        assertApproxEqAbs(
-            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 1, "morphoSupply != morphoSupplyBefore"
+        assertApproxEqDust(
+            market.supplyOf(address(morpho)), test.morphoSupplyBefore, "morphoSupply != morphoSupplyBefore"
         );
-        assertApproxEqAbs(morphoVariableBorrow, test.supplied, 2, "morphoVariableBorrow != supplied");
+        assertApproxEqDust(morphoVariableBorrow, test.supplied, "morphoVariableBorrow != supplied");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");
 
         // Assert user's underlying balance.
@@ -374,17 +370,15 @@ contract TestIntegrationWithdraw is IntegrationTest {
 
         // Assert Morpho's market state.
         assertEq(test.morphoMarket.deltas.supply.scaledDelta, 0, "scaledSupplyDelta != 0");
-        assertApproxEqAbs(test.morphoMarket.deltas.supply.scaledP2PTotal, 0, 1, "scaledTotalSupplyP2P != supplied");
-        assertApproxEqAbs(
+        assertApproxEqDust(test.morphoMarket.deltas.supply.scaledP2PTotal, 0, "scaledTotalSupplyP2P != supplied");
+        assertApproxEqDust(
             test.morphoMarket.deltas.borrow.scaledDelta.rayMul(test.indexes.borrow.poolIndex),
             morphoVariableBorrow,
-            1,
             "scaledBorrowDelta != morphoVariableBorrow"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             test.morphoMarket.deltas.borrow.scaledP2PTotal.rayMul(test.indexes.borrow.p2pIndex),
             test.supplied,
-            1,
             "scaledTotalBorrowP2P != supplied"
         );
         assertEq(test.morphoMarket.idleSupply, 0, "idleSupply != 0");

--- a/test/integration/TestIntegrationWithdrawCollateral.sol
+++ b/test/integration/TestIntegrationWithdrawCollateral.sol
@@ -68,8 +68,8 @@ contract TestIntegrationWithdrawCollateral is IntegrationTest {
         assertEq(morpho.collateralBalance(market.underlying, onBehalf), 0, "collateral != 0");
 
         // Assert Morpho's position on pool.
-        assertApproxEqAbs(
-            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 1, "morphoSupply != morphoSupplyBefore"
+        assertApproxEqDust(
+            market.supplyOf(address(morpho)), test.morphoSupplyBefore, "morphoSupply != morphoSupplyBefore"
         );
         assertEq(market.variableBorrowOf(address(morpho)), 0, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");

--- a/test/internal/TestInternalMatchingEngine.sol
+++ b/test/internal/TestInternalMatchingEngine.sol
@@ -106,7 +106,7 @@ contract TestInternalMatchingEngine is InternalTest, MatchingEngine {
         uint256 totalP2PSupply;
         for (uint256 i; i < numSuppliers; i++) {
             address user = address(vm.addr(i + 1));
-            assertApproxEqDust(
+            assertApproxEq(
                 marketBalances.scaledPoolSupplyBalance(user) + marketBalances.scaledP2PSupplyBalance(user),
                 USER_AMOUNT,
                 "user supply"
@@ -115,7 +115,7 @@ contract TestInternalMatchingEngine is InternalTest, MatchingEngine {
         }
 
         assertEq(promoted, expectedPromoted, "promoted");
-        assertApproxEqDust(totalP2PSupply, promoted, "total borrow");
+        assertApproxEq(totalP2PSupply, promoted, "total borrow");
         assertEq(iterationsDone, expectedIterations, "iterations");
     }
 
@@ -149,7 +149,7 @@ contract TestInternalMatchingEngine is InternalTest, MatchingEngine {
         uint256 totalP2PBorrow;
         for (uint256 i; i < numBorrowers; i++) {
             address user = vm.addr(i + 1);
-            assertApproxEqDust(
+            assertApproxEq(
                 marketBalances.scaledPoolBorrowBalance(user) + marketBalances.scaledP2PBorrowBalance(user),
                 USER_AMOUNT,
                 "user borrow"
@@ -158,7 +158,7 @@ contract TestInternalMatchingEngine is InternalTest, MatchingEngine {
         }
 
         assertEq(promoted, expectedPromoted, "promoted");
-        assertApproxEqDust(totalP2PBorrow, promoted, "total borrow");
+        assertApproxEq(totalP2PBorrow, promoted, "total borrow");
         assertEq(iterationsDone, expectedIterations, "iterations");
     }
 
@@ -192,7 +192,7 @@ contract TestInternalMatchingEngine is InternalTest, MatchingEngine {
         uint256 totalP2PSupply;
         for (uint256 i; i < numSuppliers; i++) {
             address user = vm.addr(i + 1);
-            assertApproxEqDust(
+            assertApproxEq(
                 marketBalances.scaledPoolSupplyBalance(user) + marketBalances.scaledP2PSupplyBalance(user),
                 USER_AMOUNT,
                 "user supply"
@@ -234,7 +234,7 @@ contract TestInternalMatchingEngine is InternalTest, MatchingEngine {
         uint256 totalP2PBorrow;
         for (uint256 i; i < numBorrowers; i++) {
             address user = vm.addr(i + 1);
-            assertApproxEqDust(
+            assertApproxEq(
                 marketBalances.scaledPoolBorrowBalance(user) + marketBalances.scaledP2PBorrowBalance(user),
                 USER_AMOUNT,
                 "user borrow"

--- a/test/internal/TestInternalMorphoInternal.sol
+++ b/test/internal/TestInternalMorphoInternal.sol
@@ -152,13 +152,12 @@ contract TestInternalMorphoInternal is InternalTest {
         emit Events.P2PDeltasIncreased(underlying, expectedAmount);
         this.increaseP2PDeltasTest(underlying, amount);
 
-        assertApproxEqAbs(
-            aTokenBalanceBefore + expectedAmount, ERC20(market.aToken).balanceOf(address(this)), 1, "aToken balance"
+        assertApproxEqDust(
+            aTokenBalanceBefore + expectedAmount, ERC20(market.aToken).balanceOf(address(this)), "aToken balance"
         );
-        assertApproxEqAbs(
+        assertApproxEqDust(
             variableDebtTokenBalanceBefore + expectedAmount,
             ERC20(market.variableDebtToken).balanceOf(address(this)),
-            1,
             "variable debt token balance"
         );
         assertEq(deltas.supply.scaledDelta, newExpectedSupplyDelta, "supply delta");
@@ -451,7 +450,7 @@ contract TestInternalMorphoInternal is InternalTest {
 
         uint256 expectedDebtValue =
             (_getUserBorrowBalanceFromIndexes(dai, address(1), indexes)) * underlyingPrice / underlyingUnit;
-        assertApproxEqAbs(debt, expectedDebtValue, 1, "debtValue not equal to expected");
+        assertApproxEqDust(debt, expectedDebtValue, "debtValue not equal to expected");
     }
 
     function testLiquidityDataAllCollaterals() public {
@@ -516,8 +515,8 @@ contract TestInternalMorphoInternal is InternalTest {
 
         uint256[3] memory debtSingles = [_debt(dai, vars), _debt(wbtc, vars), _debt(usdc, vars)];
 
-        assertApproxEqAbs(
-            debt, debtSingles[0] + debtSingles[1] + debtSingles[2], 1, "collateral not equal to sum of singles"
+        assertApproxEqDust(
+            debt, debtSingles[0] + debtSingles[1] + debtSingles[2], "collateral not equal to sum of singles"
         );
     }
 

--- a/test/internal/TestInternalPositionsManagerInternal.sol
+++ b/test/internal/TestInternalPositionsManagerInternal.sol
@@ -419,8 +419,8 @@ contract TestInternalPositionsManagerInternal is InternalTest, PositionsManagerI
         (actual.amountToLiquidate, actual.amountToSeize) =
             _calculateAmountToSeize(wbtc, dai, maxToLiquidate, address(1), indexes.supply.poolIndex);
 
-        assertApproxEqAbs(actual.amountToSeize, expected.amountToSeize, 1, "amount to seize not equal");
-        assertApproxEqAbs(actual.amountToLiquidate, expected.amountToLiquidate, 1, "amount to liquidate not equal");
+        assertApproxEqDust(actual.amountToSeize, expected.amountToSeize, "amount to seize not equal");
+        assertApproxEqDust(actual.amountToLiquidate, expected.amountToLiquidate, "amount to liquidate not equal");
     }
 
     function validatePermission(address owner, address manager) public view {

--- a/test/unit/TestUnitMarketLibIdle.sol
+++ b/test/unit/TestUnitMarketLibIdle.sol
@@ -110,9 +110,9 @@ contract TestUnitMarketLibIdle is ForkTest {
         assertGt(idleSupplyIncrease, 0, "idleSupplyIncrease is zero");
 
         // Note: Max rounding error should be 1 from the difference in supply gap calculations from an extra rayMul.
-        assertApproxEqAbs(suppliable, supplyGap, 1, "suppliable");
-        assertApproxEqAbs(idleSupplyIncrease, expectedIdleIncrease, 1, "idleSupplyIncrease");
-        assertApproxEqAbs(market.idleSupply, _market.idleSupply + expectedIdleIncrease, 1, "market.idleSupply");
+        assertApproxEq(suppliable, supplyGap, "suppliable");
+        assertApproxEq(idleSupplyIncrease, expectedIdleIncrease, "idleSupplyIncrease");
+        assertApproxEq(market.idleSupply, _market.idleSupply + expectedIdleIncrease, "market.idleSupply");
     }
 
     function testDecreaseIdle(Types.Market memory _market, uint256 amount) public {


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request introduces a new assert utility, testing for a maximum rounding error of `10 * DUST_THRESHOLD`. The rationale is:
- `DUST_THRESHOLD` represents the maximum order of magnitude of an acceptable rounding error on a scaled balance
- `10 * DUST_THRESHOLD` represents the maximum order of magnitude of an acceptable rounding error on an underlying balance
- we no longer assert exact errors, but rather the order of magnitude: this has the benefit of increasing the tolerance, but ease test maintainability (we don't need to change the tolerance everytime we have friction with a test)

The order of magnitude tested depends on the type of variable, and should be coherent throughout the test suite: scaled balance should be tested up to the wei most of the time, whereas underlying balances should be checked up to 10 wei