### PR TITLE
Claim rewards on Aave first

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -268,8 +268,8 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
         if (address(_rewardsManager) == address(0)) revert Errors.AddressIsZero();
         if (_isClaimRewardsPaused) revert Errors.ClaimRewardsPaused();
 
-        (rewardTokens, claimedAmounts) = _rewardsManager.claimRewards(assets, onBehalf);
         IRewardsController(_rewardsManager.REWARDS_CONTROLLER()).claimAllRewardsToSelf(assets);
+        (rewardTokens, claimedAmounts) = _rewardsManager.claimRewards(assets, onBehalf);
 
         for (uint256 i; i < rewardTokens.length; ++i) {
             uint256 claimedAmount = claimedAmounts[i];


### PR DESCRIPTION
The idea is to update the Aave indexes in storage first and then claim the rewards on Morpho. There are 2 reasons for this simple change:
- efficiency, as there is no need to compute virtually updated indexes when they are already up to date
- accuracy, as there could be some rounding errors when computing virtually updated indexes
