### PR TITLE
Decrease fuzz runs

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -15,12 +15,12 @@ on:
       internal-fuzz-runs:
         description: The number of fuzz rounds to perform for each fuzzing unit test.
         required: false
-        default: 128
+        default: 64
         type: number
       integration-fuzz-runs:
         description: The number of fuzz rounds to perform for each fuzzing unit test.
         required: false
-        default: 128
+        default: 64
         type: number
       invariant-runs:
         description: The number of runs to perform for invariant tests.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/forge-test.yml
     with:
       network: ethereum-mainnet
-      internal-fuzz-runs: 256
-      integration-fuzz-runs: 256
+      internal-fuzz-runs: 128
+      integration-fuzz-runs: 128
       invariant-depth: 1024
     secrets: inherit


### PR DESCRIPTION
Foundry team must have merged something that degrades ci perfs >:( (internal tests are taking 15m on PRs and integration = 35min)