### PR TITLE
Allow the DAO to unset any asset as collateral on pool

### DIFF
--- a/src/MorphoSetters.sol
+++ b/src/MorphoSetters.sol
@@ -83,9 +83,10 @@ abstract contract MorphoSetters is IMorphoSetters, MorphoInternal {
     /// @dev The following invariant must hold: is collateral on Morpho => is collateral on pool.
     /// @dev Note that it is possible to set an asset as non-collateral even if the market is not created yet on Morpho.
     ///      This is needed because an aToken with LTV = 0 can be sent to Morpho and would be set as collateral by default, thus blocking withdrawals from the pool.
+    ///      However, it's not possible to set an asset as collateral on pool while the market is not created on Morpho.
     function setAssetIsCollateralOnPool(address underlying, bool isCollateral) external onlyOwner {
         Types.Market storage market = _market[underlying];
-        if (isCollateral && !market.isCreated()) revert Errors.MarketNotCreated();
+        if (isCollateral && !market.isCreated()) revert Errors.SetAsCollateralOnPoolButMarketNotCreated();
         if (market.isCollateral) revert Errors.AssetIsCollateralOnMorpho();
 
         _pool.setUserUseReserveAsCollateral(underlying, isCollateral);

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -102,6 +102,9 @@ library Errors {
     /// @notice Thrown when (un)setting a market as collateral on Aave while it is a collateral on Morpho.
     error AssetIsCollateralOnMorpho();
 
+    /// @notice Thrown when setting a market as collateral on Aave while the market is not created on Morpho.
+    error SetAsCollateralOnPoolButMarketNotCreated();
+
     /// @notice Thrown when the value exceeds the maximum basis points value (100% = 10000).
     error ExceedsMaxBasisPoints();
 

--- a/test/integration/TestIntegrationAssetAsCollateral.sol
+++ b/test/integration/TestIntegrationAssetAsCollateral.sol
@@ -87,7 +87,7 @@ contract TestIntegrationAssetAsCollateral is IntegrationTest {
         assertEq(morpho.market(link).isCollateral, false);
         assertEq(_isUsingAsCollateral(link), false);
 
-        vm.expectRevert(Errors.MarketNotCreated.selector);
+        vm.expectRevert(Errors.SetAsCollateralOnPoolButMarketNotCreated.selector);
         morpho.setAssetIsCollateralOnPool(link, true);
     }
 
@@ -157,6 +157,9 @@ contract TestIntegrationAssetAsCollateral is IntegrationTest {
 
         assertEq(morpho.market(link).isCollateral, false);
         assertEq(_isUsingAsCollateral(link), false);
+
+        vm.expectRevert(Errors.SetAsCollateralOnPoolButMarketNotCreated.selector);
+        morpho.setAssetIsCollateralOnPool(link, true);
     }
 
     function testSetAssetIsNotCollateralOnPoolWhenMarketIsCreatedAndIsNotCollateralOnMorphoOnly() public {


### PR DESCRIPTION
Aave is not doing the upgrade. We can't really postpone the deployment forever so here is a PR to re-enable the possibility to unset an asset as collateral on pool even if the market is not created.

Related PR: https://github.com/morpho-dao/morpho-aave-v3/pull/680