### PR TITLE
bulker: remove ops and add skim

### DIFF
--- a/src/extensions/BulkerGateway.sol
+++ b/src/extensions/BulkerGateway.sol
@@ -31,9 +31,6 @@ contract BulkerGateway is IBulkerGateway {
     /// @dev The address of the wstETH contract.
     address internal constant _WST_ETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
 
-    /// @dev The address of the Morpho DAO.
-    address internal constant _MORPHO_DAO = 0xcBa28b38103307Ec8dA98377ffF9816C164f9AFa;
-
     /* IMMUTABLES */
 
     IMorpho internal immutable _MORPHO;
@@ -70,11 +67,6 @@ contract BulkerGateway is IBulkerGateway {
     /// @notice Returns the address of the Morpho protocol.
     function MORPHO() external view returns (address) {
         return address(_MORPHO);
-    }
-
-    /// @notice Returns the address of the Morpho DAO.
-    function MORPHO_DAO() external pure returns (address) {
-        return _MORPHO_DAO;
     }
 
     /// @notice Executes the given batch of actions, with the given input data.

--- a/src/interfaces/IBulkerGateway.sol
+++ b/src/interfaces/IBulkerGateway.sol
@@ -52,7 +52,6 @@ interface IBulkerGateway {
     function wstETH() external pure returns (address);
 
     function MORPHO() external view returns (address);
-    function MORPHO_DAO() external pure returns (address);
 
     function execute(ActionType[] calldata actions, bytes[] calldata data) external payable;
 }


### PR DESCRIPTION
A proposed removal of all ops, returns, and lastOutputAmounts in the bulker. With the removal of swaps, there is no longer a need to anticipate a significant variance in output amounts. In addition, with the availability of skim to any user, users can recover dust amounts if they would like to.