### PR TITLE
Add liquidation collateral receiver parameter (POC)

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -206,11 +206,14 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
     /// @param user The address of the user to liquidate.
     /// @param amount The amount of `underlyingBorrowed` to repay.
     /// @return The `underlyingBorrowed` amount repaid (in underlying) and the `underlyingCollateral` amount seized (in underlying).
-    function liquidate(address underlyingBorrowed, address underlyingCollateral, address user, uint256 amount)
-        external
-        returns (uint256, uint256)
-    {
-        return _liquidate(underlyingBorrowed, underlyingCollateral, amount, user, msg.sender);
+    function liquidate(
+        address underlyingBorrowed,
+        address underlyingCollateral,
+        address user,
+        uint256 amount,
+        address collateralReceiver
+    ) external returns (uint256, uint256) {
+        return _liquidate(underlyingBorrowed, underlyingCollateral, amount, user, msg.sender, collateralReceiver);
     }
 
     /// @notice Approves a `manager` to borrow/withdraw on behalf of the sender.
@@ -350,12 +353,13 @@ contract Morpho is IMorpho, MorphoGetters, MorphoSetters {
         address underlyingCollateral,
         uint256 amount,
         address borrower,
-        address liquidator
+        address liquidator,
+        address collateralReceiver
     ) internal returns (uint256 repaid, uint256 seized) {
         bytes memory returnData = _positionsManager.functionDelegateCall(
             abi.encodeCall(
                 IPositionsManager.liquidateLogic,
-                (underlyingBorrowed, underlyingCollateral, amount, borrower, liquidator)
+                (underlyingBorrowed, underlyingCollateral, amount, borrower, liquidator, collateralReceiver)
             )
         );
 

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -130,9 +130,13 @@ interface IMorpho is IMorphoGetters, IMorphoSetters {
         Types.Signature calldata signature
     ) external;
 
-    function liquidate(address underlyingBorrowed, address underlyingCollateral, address user, uint256 amount)
-        external
-        returns (uint256 repaid, uint256 seized);
+    function liquidate(
+        address underlyingBorrowed,
+        address underlyingCollateral,
+        address user,
+        uint256 amount,
+        address collateralReceiver
+    ) external returns (uint256 repaid, uint256 seized);
 
     function claimRewards(address[] calldata assets, address onBehalf)
         external

--- a/src/interfaces/IPositionsManager.sol
+++ b/src/interfaces/IPositionsManager.sol
@@ -34,6 +34,7 @@ interface IPositionsManager {
         address underlyingCollateral,
         uint256 amount,
         address borrower,
-        address liquidator
+        address liquidator,
+        address collateralReceiver
     ) external returns (uint256 liquidated, uint256 seized);
 }


### PR DESCRIPTION
The idea is that a third-party actor would still be able to liquidate a position on Morpho, providing necessary capital upfront, without necessarily withdrawing the collateral from the pool atomically. This would be necessary in the case of the pool of collateral being illiquid. But nobody from the team seems to be convinced that such a liquidator, providing capital upfront, bearing the risk of Morpho afterwards, would exist or act under such circumstances.

(I only spent 5min on this)