### PR TITLE
Document Rewards Manager getter

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -240,7 +240,7 @@ contract RewardsManager is IRewardsManager, Initializable {
     }
 
     /// @notice Returns the user's index for the specified asset and reward token.
-    /// @dev If an already listed AaveV3 reward is not yet tracked (startingIndex == 0), this view function ignores that it'll get updated upon interaction.
+    /// @dev If an already listed AaveV3 reward token is not yet tracked (startingIndex == 0), this view function ignores that it will get updated upon interaction.
     /// @param user The address of the user.
     /// @param asset The address of the reference asset of the distribution (aToken or variable debt token).
     /// @param reward The address of the reward token.


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request:

- fixes #794 
- fixes https://github.com/spearbit-audits/review-morpho-Aave-v3/issues/46

There are 3 ways to fix this:
1. Don't virtually set the starting index in the getter, acknowledge that the getter only exposes the stored user index
2. Duplicate starting index query
3. Do what this PR does: avoid making 2 calls to the rewards controller by factoring the starting index with the asset reward indexes query

PS: the rewards manager is spaghetti code because too many intermediary getters are exposed. Without exposing the asset index & the user indexes (which require factoring the query to the rewards controller but not the storage update), we'd have a much cleaner code...
