### PR TITLE
Fix rewards accrual

### DIFF
--- a/src/MorphoInternal.sol
+++ b/src/MorphoInternal.sol
@@ -356,58 +356,6 @@ abstract contract MorphoInternal is MorphoStorage {
         }
     }
 
-    /// @dev Updates a `user`'s position in the data structure.
-    /// @param underlying The address of the underlying asset.
-    /// @param user The address of the user to update.
-    /// @param onPool The new scaled balance on pool of the `user`.
-    /// @param inP2P The new scaled balance in peer-to-peer of the `user`.
-    /// @param demoting Whether the update is happening during a demoting process or not.
-    /// @param supply Whether the balance updated is a supply or borrow.
-    /// @return The actual new scaled balance on pool and in peer-to-peer of the `user` after accounting for dust.
-    function _updateInDS(address underlying, address user, uint256 onPool, uint256 inP2P, bool demoting, bool supply)
-        internal
-        returns (uint256, uint256)
-    {
-        if (onPool <= Constants.DUST_THRESHOLD) onPool = 0;
-        if (inP2P <= Constants.DUST_THRESHOLD) inP2P = 0;
-
-        Types.MarketBalances storage marketBalances = _marketBalances[underlying];
-
-        LogarithmicBuckets.Buckets storage poolBuckets;
-        LogarithmicBuckets.Buckets storage p2pBuckets;
-
-        if (supply) {
-            poolBuckets = marketBalances.poolSuppliers;
-            p2pBuckets = marketBalances.p2pSuppliers;
-        } else {
-            poolBuckets = marketBalances.poolBorrowers;
-            p2pBuckets = marketBalances.p2pBorrowers;
-        }
-
-        uint256 formerOnPool = poolBuckets.valueOf[user];
-
-        if (onPool != formerOnPool) {
-            address poolToken;
-            uint256 totalOnPool = formerOnPool;
-
-            if (supply) {
-                poolToken = _market[underlying].aToken;
-                totalOnPool += marketBalances.scaledCollateralBalance(user);
-            } else {
-                poolToken = _market[underlying].variableDebtToken;
-            }
-
-            _updateRewards(user, poolToken, totalOnPool);
-
-            poolBuckets.update(user, onPool, demoting);
-        }
-
-        uint256 formerInP2P = p2pBuckets.valueOf[user];
-
-        if (inP2P != formerInP2P) p2pBuckets.update(user, inP2P, true);
-        return (onPool, inP2P);
-    }
-
     /// @dev Updates a `user`'s supply position in the data structure.
     /// @param underlying The address of the underlying asset.
     /// @param user The address of the user to update.
@@ -419,7 +367,28 @@ abstract contract MorphoInternal is MorphoStorage {
         internal
         returns (uint256, uint256)
     {
-        return _updateInDS(underlying, user, onPool, inP2P, demoting, true);
+        if (onPool <= Constants.DUST_THRESHOLD) onPool = 0;
+        if (inP2P <= Constants.DUST_THRESHOLD) inP2P = 0;
+
+        Types.MarketBalances storage marketBalances = _marketBalances[underlying];
+
+        LogarithmicBuckets.Buckets storage poolBuckets = marketBalances.poolSuppliers;
+        uint256 formerOnPool = poolBuckets.valueOf[user];
+
+        if (onPool != formerOnPool) {
+            _updateRewards(
+                user, _market[underlying].aToken, formerOnPool + marketBalances.scaledCollateralBalance(user)
+            );
+
+            poolBuckets.update(user, onPool, demoting);
+        }
+
+        LogarithmicBuckets.Buckets storage p2pBuckets = marketBalances.p2pSuppliers;
+        uint256 formerInP2P = p2pBuckets.valueOf[user];
+
+        if (inP2P != formerInP2P) p2pBuckets.update(user, inP2P, true);
+
+        return (onPool, inP2P);
         // No need to update the user's list of supplied assets,
         // as it cannot be used as collateral and thus there's no need to iterate over it.
     }
@@ -435,7 +404,24 @@ abstract contract MorphoInternal is MorphoStorage {
         internal
         returns (uint256, uint256)
     {
-        (onPool, inP2P) = _updateInDS(underlying, user, onPool, inP2P, demoting, false);
+        if (onPool <= Constants.DUST_THRESHOLD) onPool = 0;
+        if (inP2P <= Constants.DUST_THRESHOLD) inP2P = 0;
+
+        Types.MarketBalances storage marketBalances = _marketBalances[underlying];
+
+        LogarithmicBuckets.Buckets storage poolBuckets = marketBalances.poolBorrowers;
+        uint256 formerOnPool = poolBuckets.valueOf[user];
+
+        if (onPool != formerOnPool) {
+            _updateRewards(user, _market[underlying].variableDebtToken, formerOnPool);
+
+            poolBuckets.update(user, onPool, demoting);
+        }
+
+        LogarithmicBuckets.Buckets storage p2pBuckets = marketBalances.p2pBorrowers;
+        uint256 formerInP2P = p2pBuckets.valueOf[user];
+
+        if (inP2P != formerInP2P) p2pBuckets.update(user, inP2P, true);
 
         if (onPool == 0 && inP2P == 0) _userBorrows[user].remove(underlying);
         else _userBorrows[user].add(underlying);

--- a/src/PositionsManagerInternal.sol
+++ b/src/PositionsManagerInternal.sol
@@ -416,7 +416,9 @@ abstract contract PositionsManagerInternal is MatchingEngine {
 
         collateralBalance = marketBalances.collateral[onBehalf];
 
-        _updateRewards(onBehalf, _market[underlying].aToken, collateralBalance);
+        _updateRewards(
+            onBehalf, _market[underlying].aToken, collateralBalance + marketBalances.poolSuppliers.valueOf[onBehalf]
+        );
 
         collateralBalance += amount.rayDivDown(poolSupplyIndex);
 
@@ -434,7 +436,9 @@ abstract contract PositionsManagerInternal is MatchingEngine {
 
         collateralBalance = marketBalances.collateral[onBehalf];
 
-        _updateRewards(onBehalf, _market[underlying].aToken, collateralBalance);
+        _updateRewards(
+            onBehalf, _market[underlying].aToken, collateralBalance + marketBalances.poolSuppliers.valueOf[onBehalf]
+        );
 
         collateralBalance = collateralBalance.zeroFloorSub(amount.rayDivUp(poolSupplyIndex));
 

--- a/src/PositionsManagerInternal.sol
+++ b/src/PositionsManagerInternal.sol
@@ -437,7 +437,7 @@ abstract contract PositionsManagerInternal is MatchingEngine {
         collateralBalance = marketBalances.collateral[onBehalf];
 
         _updateRewards(
-            onBehalf, _market[underlying].aToken, collateralBalance + marketBalances.poolSuppliers.valueOf[onBehalf]
+            onBehalf, _market[underlying].aToken, collateralBalance + marketBalances.scaledPoolSupplyBalance(onBehalf)
         );
 
         collateralBalance = collateralBalance.zeroFloorSub(amount.rayDivUp(poolSupplyIndex));

--- a/src/PositionsManagerInternal.sol
+++ b/src/PositionsManagerInternal.sol
@@ -417,7 +417,7 @@ abstract contract PositionsManagerInternal is MatchingEngine {
         collateralBalance = marketBalances.collateral[onBehalf];
 
         _updateRewards(
-            onBehalf, _market[underlying].aToken, collateralBalance + marketBalances.poolSuppliers.valueOf[onBehalf]
+            onBehalf, _market[underlying].aToken, collateralBalance + marketBalances.scaledPoolSupplyBalance(onBehalf)
         );
 
         collateralBalance += amount.rayDivDown(poolSupplyIndex);

--- a/test/integration/TestIntegrationRewardsManager.sol
+++ b/test/integration/TestIntegrationRewardsManager.sol
@@ -444,4 +444,27 @@ contract TestIntegrationRewardsManager is IntegrationTest {
         assertEq(amounts[0], accruedRewardCollateral + accruedRewardBorrow, "amount 1");
         assertGt(amounts[0], 0, "amount min 1");
     }
+
+    function testShouldAccrueSupplyAndCollateralRewards() public {
+        uint256 amount = 1 ether;
+
+        user.approve(dai, amount);
+        user.supplyCollateral(dai, amount);
+
+        _forward(1);
+
+        address[] memory aDaiArray = new address[](1);
+        aDaiArray[0] = aDai;
+
+        uint256 accruedRewardsBefore = rewardsManager.getUserRewards(aDaiArray, address(user), wNative);
+
+        user.approve(dai, amount);
+        user.supply(dai, amount);
+
+        _forward(1);
+
+        uint256 accruedRewardsAfter = rewardsManager.getUserRewards(aDaiArray, address(user), wNative);
+
+        assertEq(accruedRewardsAfter, accruedRewardsBefore * 3);
+    }
 }

--- a/test/integration/TestIntegrationRewardsManager.sol
+++ b/test/integration/TestIntegrationRewardsManager.sol
@@ -465,6 +465,6 @@ contract TestIntegrationRewardsManager is IntegrationTest {
 
         uint256 accruedRewardsAfter = rewardsManager.getUserRewards(aDaiArray, address(user), wNative);
 
-        assertEq(accruedRewardsAfter, accruedRewardsBefore * 3);
+        assertApproxEqAbs(accruedRewardsAfter, accruedRewardsBefore * 3, 1e5);
     }
 }

--- a/test/integration/TestIntegrationWithdraw.sol
+++ b/test/integration/TestIntegrationWithdraw.sol
@@ -72,7 +72,7 @@ contract TestIntegrationWithdraw is IntegrationTest {
 
         // Assert Morpho's position on pool.
         assertApproxEqAbs(
-            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 1, "morphoSupply != morphoSupplyBefore"
+            market.supplyOf(address(morpho)), test.morphoSupplyBefore, 2, "morphoSupply != morphoSupplyBefore"
         );
         assertApproxEqAbs(market.variableBorrowOf(address(morpho)), 0, 2, "morphoVariableBorrow != 0");
         assertEq(market.stableBorrowOf(address(morpho)), 0, "morphoStableBorrow != 0");

--- a/test/internal/TestInternalMorphoInternal.sol
+++ b/test/internal/TestInternalMorphoInternal.sol
@@ -233,9 +233,7 @@ contract TestInternalMorphoInternal is InternalTest {
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
 
         Types.MarketBalances storage marketBalances = _marketBalances[dai];
-        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(
-            address(0), user, marketBalances.poolSuppliers, marketBalances.p2pSuppliers, onPool, inP2P, head
-        );
+        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, true);
         assertEq(newOnPool, onPool);
         assertEq(newInP2P, inP2P);
         _assertMarketBalances(marketBalances, user, onPool, inP2P, 0, 0, 0);
@@ -247,30 +245,24 @@ contract TestInternalMorphoInternal is InternalTest {
         inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
 
         Types.MarketBalances storage marketBalances = _marketBalances[dai];
-        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(
-            address(0), user, marketBalances.poolBorrowers, marketBalances.p2pBorrowers, onPool, inP2P, head
-        );
+        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, false);
         assertEq(newOnPool, onPool);
         assertEq(newInP2P, inP2P);
         _assertMarketBalances(marketBalances, user, 0, 0, onPool, inP2P, 0);
     }
 
-    function testUpdateInDSWithDust(address user, uint256 onPool, uint256 inP2P, bool head) public {
+    function testUpdateInDSWithDust(address user, uint256 onPool, uint256 inP2P, bool head, bool supply) public {
         user = _boundAddressNotZero(user);
         onPool = bound(onPool, 0, Constants.DUST_THRESHOLD);
         inP2P = bound(inP2P, 0, Constants.DUST_THRESHOLD);
 
         Types.MarketBalances storage marketBalances = _marketBalances[dai];
-        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(
-            address(0), user, marketBalances.poolSuppliers, marketBalances.p2pSuppliers, onPool, inP2P, head
-        );
+        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, supply);
         _assertMarketBalances(marketBalances, user, 0, 0, 0, 0, 0);
         assertEq(newOnPool, 0);
         assertEq(newInP2P, 0);
 
-        (newOnPool, newInP2P) = _updateInDS(
-            address(0), user, marketBalances.poolBorrowers, marketBalances.p2pBorrowers, onPool, inP2P, head
-        );
+        (newOnPool, newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, supply);
         assertEq(newOnPool, 0);
         assertEq(newInP2P, 0);
         _assertMarketBalances(marketBalances, user, 0, 0, 0, 0, 0);

--- a/test/internal/TestInternalMorphoInternal.sol
+++ b/test/internal/TestInternalMorphoInternal.sol
@@ -227,47 +227,6 @@ contract TestInternalMorphoInternal is InternalTest {
         assertEq(marketBalances.scaledCollateralBalance(user), scaledCollateral, "scaledCollateral");
     }
 
-    function testUpdateInDSWithSuppliers(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotZero(user);
-        onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
-        inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
-
-        Types.MarketBalances storage marketBalances = _marketBalances[dai];
-        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, true);
-        assertEq(newOnPool, onPool);
-        assertEq(newInP2P, inP2P);
-        _assertMarketBalances(marketBalances, user, onPool, inP2P, 0, 0, 0);
-    }
-
-    function testUpdateInDSWithBorrowers(address user, uint256 onPool, uint256 inP2P, bool head) public {
-        user = _boundAddressNotZero(user);
-        onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);
-        inP2P = bound(inP2P, Constants.DUST_THRESHOLD + 1, type(uint96).max);
-
-        Types.MarketBalances storage marketBalances = _marketBalances[dai];
-        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, false);
-        assertEq(newOnPool, onPool);
-        assertEq(newInP2P, inP2P);
-        _assertMarketBalances(marketBalances, user, 0, 0, onPool, inP2P, 0);
-    }
-
-    function testUpdateInDSWithDust(address user, uint256 onPool, uint256 inP2P, bool head, bool supply) public {
-        user = _boundAddressNotZero(user);
-        onPool = bound(onPool, 0, Constants.DUST_THRESHOLD);
-        inP2P = bound(inP2P, 0, Constants.DUST_THRESHOLD);
-
-        Types.MarketBalances storage marketBalances = _marketBalances[dai];
-        (uint256 newOnPool, uint256 newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, supply);
-        _assertMarketBalances(marketBalances, user, 0, 0, 0, 0, 0);
-        assertEq(newOnPool, 0);
-        assertEq(newInP2P, 0);
-
-        (newOnPool, newInP2P) = _updateInDS(dai, user, onPool, inP2P, head, supply);
-        assertEq(newOnPool, 0);
-        assertEq(newInP2P, 0);
-        _assertMarketBalances(marketBalances, user, 0, 0, 0, 0, 0);
-    }
-
     function testUpdateSupplierInDS(address user, uint256 onPool, uint256 inP2P, bool head) public {
         user = _boundAddressNotZero(user);
         onPool = bound(onPool, Constants.DUST_THRESHOLD + 1, type(uint96).max);


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request:

- fixes https://github.com/spearbit-audits/review-morpho-june/issues/28#issuecomment-1582196383

This is a fix to the vulnerability disclosed by Spearbit, which cannot be used in production currently because:
- no rewards are currently distributed by Aave on mainnet
- no RewardsManager is deployed nor set on MorphoAaveV3-ETH

But this PR should be reviewed and ready to deploy as soon as the Morpho DAO decides to distribute Aave-emitted rewards to users, following an Aave governance proposal.