### PR TITLE
Bump versions of gas-diff and storage-checker

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: ./.github/actions/install
 
       - name: Check Morpho storage layout
-        uses: Rubilmax/foundry-storage-check@v3.7
+        uses: Rubilmax/foundry-storage-check@v3
         with:
           contract: src/Morpho.sol:Morpho
           rpcUrl: wss://eth-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_KEY }}
@@ -174,7 +174,7 @@ jobs:
           FOUNDRY_FUZZ_SEED: 0x${{ github.event.pull_request.base.sha || github.sha }}
 
       - name: Compare gas reports
-        uses: Rubilmax/foundry-gas-diff@v3.13.4
+        uses: Rubilmax/foundry-gas-diff@v3
         id: gas_diff
         with:
           match: src/Morpho.sol


### PR DESCRIPTION
This fixes some warnings on deprecated Node and artifacts versions:
![Screenshot from 2024-10-23 15-01-27](https://github.com/user-attachments/assets/a6b9c309-2cc1-48a7-b1e9-26b6d6bba7fc)
