### PR TITLE
Rounding in some tests

### DIFF
--- a/test/extensions/TestIntegrationSupplyVault.sol
+++ b/test/extensions/TestIntegrationSupplyVault.sol
@@ -110,7 +110,7 @@ contract TestIntegrationSupplyVault is TestSetupVaults {
         assertApproxEqAbs(
             ERC20(usdc).balanceOf(address(user)), balanceBeforeDeposit, 5, "amount withdrawn != amount deposited"
         );
-        assertApproxEqAbs(totalBalanceAfter, totalBalanceBefore, 1, "totalBalance");
+        assertApproxEqAbs(totalBalanceAfter, totalBalanceBefore, 2, "totalBalance");
         assertApproxEqAbs(ERC20(usdc).balanceOf(address(user)) - balanceBeforeWithdraw, amount, 2, "expectedWithdraw");
     }
 

--- a/test/integration/TestIntegrationLiquidate.sol
+++ b/test/integration/TestIntegrationLiquidate.sol
@@ -394,7 +394,7 @@ contract TestIntegrationLiquidate is IntegrationTest {
         assertApproxEqAbs(
             morpho.collateralBalance(collateralMarket.underlying, borrower) + test.seized,
             test.collateralBalanceBefore,
-            1,
+            2,
             "collateralBalanceAfter != collateralBalanceBefore - seized"
         );
     }


### PR DESCRIPTION
Fixes:
- delta of 2 instead of max 1 in `testShouldWithdrawAllUsdcAmount(8093576635672732587327639569142646392586)` at fork block number `21043074`
- delta of 2 instead of max 1 in `testLiquidateUnhealthyUserWhenSentinelAllows(182894193560870927580715351256980964074235487581962067458924, 1466376882983552528741661505694, 0x0097DD9E8eBe08A7051dD4EB2f96855b805665eE, 1723744892512496395828064541720855596887574716439663605575076005980793, 3479345449443811213, 12273093960728827939432339582032883308656226731094767263933757188938418, 165893764325564789833598704768760362398602152308516592)` at fork block number `21043120`

