### PR TITLE
Larger bound for bypassing sentinel liquidation

### DIFF
--- a/test/integration/TestIntegrationLiquidate.sol
+++ b/test/integration/TestIntegrationLiquidate.sol
@@ -194,7 +194,7 @@ contract TestIntegrationLiquidate is IntegrationTest {
     ) public {
         borrower = _boundReceiver(borrower);
         promotionFactor = bound(promotionFactor, 0, WadRayMath.WAD);
-        healthFactor = bound(healthFactor, MIN_HF, Constants.DEFAULT_LIQUIDATION_MIN_HF.percentSub(1));
+        healthFactor = bound(healthFactor, MIN_HF, Constants.DEFAULT_LIQUIDATION_MIN_HF.percentSub(10));
 
         oracleSentinel.setLiquidationAllowed(false);
 


### PR DESCRIPTION
Test `testFullLiquidateUnhealthyUserWhenSentinelDisallowsButHealthFactorVeryLow`: when the health factor is very low, liquidations are allowed, even if disallowed by the sentinel. To test this behavior, it consists in creating a position with a health factor below a given bound B. This is done via the `_createPosition` utility function in tests, and pass it a given health factor that is below B.

The problem arise when passing a health factor close to B, because `_createPosition` creates a position that has over-estimated close factor. To compensate, the bound B must be lowered