### PR TITLE
Test Aave v3.3

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -11,8 +11,6 @@ runs:
 
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly
 
     - name: Restore forge compilation cache
       uses: actions/cache/restore@v4

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -11,6 +11,8 @@ runs:
 
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: v0.3.0
 
     - name: Restore forge compilation cache
       uses: actions/cache/restore@v4

--- a/.github/workflows/forge-fmt.yml
+++ b/.github/workflows/forge-fmt.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v0.3.0
 
       - name: Check formatting
         run: forge fmt --check

--- a/.github/workflows/forge-fmt.yml
+++ b/.github/workflows/forge-fmt.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Check formatting
         run: forge fmt --check

--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v0.3.0
 
       - name: Build contracts via IR & check sizes
         run: make contracts # don't use compilation cache

--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -57,8 +57,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Build contracts via IR & check sizes
         run: make contracts # don't use compilation cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 	path = lib/permit2
 	url = https://github.com/Uniswap/permit2
 	branch = f3349109ed405970a7fb3bb7e9ac9574c822a90d
+[submodule "lib/aave-v3-origin"]
+	path = lib/aave-v3-origin
+	url = git@github.com:bgd-labs/aave-v3-origin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,3 @@
 	path = lib/permit2
 	url = https://github.com/Uniswap/permit2
 	branch = f3349109ed405970a7fb3bb7e9ac9574c822a90d
-[submodule "lib/aave-v3-origin"]
-	path = lib/aave-v3-origin
-	url = git@github.com:bgd-labs/aave-v3-origin.git

--- a/foundry.toml
+++ b/foundry.toml
@@ -22,4 +22,4 @@ avalanche = "https://rpc.ankr.com/avalanche"
 tenderly = "https://rpc.tenderly.co/fork/${TENDERLY_FORK_ID}"
 
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config

--- a/remappings.txt
+++ b/remappings.txt
@@ -8,7 +8,7 @@ config/=config/
 @morpho-utils/=lib/morpho-utils/src/
 @morpho-data-structures/=lib/morpho-data-structures/src/
 
-@openzeppelin/=lib/morpho-utils/lib/openzeppelin-contracts/
+@openzeppelin/contracts/=lib/morpho-utils/lib/openzeppelin-contracts/contracts/
 @openzeppelin-upgradeable/=lib/morpho-utils/lib/openzeppelin-contracts-upgradeable/contracts/
 
 @aave-v3-core/=lib/aave-v3-core/contracts/

--- a/test/helpers/ForkTest.sol
+++ b/test/helpers/ForkTest.sol
@@ -35,6 +35,7 @@ import {
     IPoolAddressesProvider as IPoolAddr
 } from "lib/aave-v3-origin/src/contracts/instances/PoolInstance.sol";
 import {PoolConfiguratorInstance} from "lib/aave-v3-origin/src/contracts/instances/PoolConfiguratorInstance.sol";
+import {AaveProtocolDataProvider} from "lib/aave-v3-origin/src/contracts/helpers/AaveProtocolDataProvider.sol";
 
 interface IAllowanceTransferExtended is IAllowanceTransfer {
     function DOMAIN_SEPARATOR() external view returns (bytes32);
@@ -126,6 +127,10 @@ contract ForkTest is BaseTest, Configured {
         address newPoolConfiguratorImpl = address(new PoolConfiguratorInstance());
         vm.prank(aclAdmin);
         addressesProvider.setPoolConfiguratorImpl(newPoolConfiguratorImpl);
+
+        address newDataProvider = address(new AaveProtocolDataProvider(IPoolAddr(address(addressesProvider))));
+        vm.prank(aclAdmin);
+        addressesProvider.setPoolDataProvider(newDataProvider);
     }
 
     function _label() internal virtual {

--- a/test/helpers/IntegrationTest.sol
+++ b/test/helpers/IntegrationTest.sol
@@ -12,7 +12,6 @@ import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.s
 import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 import {PermitHash} from "@permit2/libraries/PermitHash.sol";
-import {IAllowanceTransfer, AllowanceTransfer} from "@permit2/AllowanceTransfer.sol";
 
 import {Morpho} from "src/Morpho.sol";
 import {PositionsManager} from "src/PositionsManager.sol";


### PR DESCRIPTION
Not meant to be merged, as it's only useful before the v3.3 update. After the update, the new code will automatically be tested.

Limitations:
- for now it is testing by compiling everything with the same version, but ma3 is compiled with 0.8.17 and aave-v3.3 is compiled with >=0.8.20
- uses foundry v0.3.0 instead of v1.0.0, because of a [compilation size bug ](https://github.com/morpho-org/morpho-aavev3-optimizer/actions/runs/13326098138/job/37219593736)