### PR TITLE
Test Aave v3.4

### DIFF
--- a/config/ethereum-mainnet.json
+++ b/config/ethereum-mainnet.json
@@ -1,6 +1,6 @@
 {
   "chainId": 1,
-  "rpcAlias": "mainnet",
+  "rpcAlias": "https://virtual.mainnet.rpc.tenderly.co/ebe7f9e9-d546-4dad-be39-5e46bd2d2c3a",
   "forkBlockNumber": 0,
   "addressesProvider": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
   "morphoDao": "0xcBa28b38103307Ec8dA98377ffF9816C164f9AFa",

--- a/config/ethereum-mainnet.json
+++ b/config/ethereum-mainnet.json
@@ -1,6 +1,6 @@
 {
   "chainId": 1,
-  "rpcAlias": "https://virtual.mainnet.rpc.tenderly.co/ebe7f9e9-d546-4dad-be39-5e46bd2d2c3a",
+  "rpcAlias": "mainnet",
   "forkBlockNumber": 0,
   "addressesProvider": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
   "morphoDao": "0xcBa28b38103307Ec8dA98377ffF9816C164f9AFa",

--- a/test/helpers/AaveErrors.sol
+++ b/test/helpers/AaveErrors.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+error SupplyCapExceeded();

--- a/test/integration/TestIntegrationMorphoGetters.sol
+++ b/test/integration/TestIntegrationMorphoGetters.sol
@@ -106,7 +106,7 @@ contract TestIntegrationMorphoGetters is IntegrationTest {
 
         uint256 poolSupplyIndexAfter = morpho.updatedIndexes(market.underlying).supply.poolIndex;
 
-        assertGt(poolSupplyIndexAfter, poolSupplyIndexBefore);
+        assertGe(poolSupplyIndexAfter, poolSupplyIndexBefore);
     }
 
     function testP2PSupplyIndexGrowthInsideBlock(uint256 seed) public {
@@ -120,6 +120,6 @@ contract TestIntegrationMorphoGetters is IntegrationTest {
 
         uint256 poolSupplyIndexAfter = morpho.updatedIndexes(market.underlying).supply.p2pIndex;
 
-        assertGt(poolSupplyIndexAfter, poolSupplyIndexBefore);
+        assertGe(poolSupplyIndexAfter, poolSupplyIndexBefore);
     }
 }

--- a/test/integration/TestIntegrationMorphoGetters.sol
+++ b/test/integration/TestIntegrationMorphoGetters.sol
@@ -95,6 +95,12 @@ contract TestIntegrationMorphoGetters is IntegrationTest {
         );
     }
 
+    function testNoFlashloanPremiumToLP() public view {
+        uint256 premiumTotal = pool.FLASHLOAN_PREMIUM_TOTAL();
+        uint256 premiumToProtocol = pool.FLASHLOAN_PREMIUM_TOTAL();
+        assertEq(premiumToProtocol, premiumTotal, "all premium goes to protocol");
+    }
+
     function testPoolSupplyIndexGrowthInsideBlock(uint256 seed) public {
         TestMarket storage market = testMarkets[_randomUnderlying(seed)];
         vm.assume(pool.getConfiguration(market.underlying).getFlashLoanEnabled());

--- a/test/integration/TestIntegrationMorphoGetters.sol
+++ b/test/integration/TestIntegrationMorphoGetters.sol
@@ -100,32 +100,4 @@ contract TestIntegrationMorphoGetters is IntegrationTest {
         uint256 premiumToProtocol = pool.FLASHLOAN_PREMIUM_TOTAL();
         assertEq(premiumToProtocol, premiumTotal, "all premium goes to protocol");
     }
-
-    function testPoolSupplyIndexGrowthInsideBlock(uint256 seed) public {
-        TestMarket storage market = testMarkets[_randomUnderlying(seed)];
-        vm.assume(pool.getConfiguration(market.underlying).getFlashLoanEnabled());
-
-        uint256 poolSupplyIndexBefore = morpho.updatedIndexes(market.underlying).supply.poolIndex;
-
-        uint256 liquidity = market.liquidity();
-        flashBorrower.flashLoanSimple(market.underlying, liquidity);
-
-        uint256 poolSupplyIndexAfter = morpho.updatedIndexes(market.underlying).supply.poolIndex;
-
-        assertGe(poolSupplyIndexAfter, poolSupplyIndexBefore);
-    }
-
-    function testP2PSupplyIndexGrowthInsideBlock(uint256 seed) public {
-        TestMarket storage market = testMarkets[_randomUnderlying(seed)];
-        vm.assume(pool.getConfiguration(market.underlying).getFlashLoanEnabled());
-
-        uint256 poolSupplyIndexBefore = morpho.updatedIndexes(market.underlying).supply.p2pIndex;
-
-        uint256 liquidity = market.liquidity();
-        flashBorrower.flashLoanSimple(market.underlying, liquidity);
-
-        uint256 poolSupplyIndexAfter = morpho.updatedIndexes(market.underlying).supply.p2pIndex;
-
-        assertGe(poolSupplyIndexAfter, poolSupplyIndexBefore);
-    }
 }

--- a/test/integration/TestIntegrationSupply.sol
+++ b/test/integration/TestIntegrationSupply.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "test/helpers/IntegrationTest.sol";
+import "test/helpers/AaveErrors.sol";
 
 contract TestIntegrationSupply is IntegrationTest {
     using WadRayMath for uint256;
@@ -312,7 +313,7 @@ contract TestIntegrationSupply is IntegrationTest {
 
         user.approve(market.underlying, amount);
 
-        vm.expectRevert(bytes(AaveErrors.SUPPLY_CAP_EXCEEDED));
+        vm.expectRevert(SupplyCapExceeded.selector);
         user.supply(market.underlying, amount, onBehalf);
     }
 

--- a/test/integration/TestIntegrationSupplyCollateral.sol
+++ b/test/integration/TestIntegrationSupplyCollateral.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "test/helpers/IntegrationTest.sol";
+import "test/helpers/AaveErrors.sol";
 
 contract TestIntegrationSupplyCollateral is IntegrationTest {
     using WadRayMath for uint256;
@@ -95,7 +96,7 @@ contract TestIntegrationSupplyCollateral is IntegrationTest {
 
         user.approve(market.underlying, amount);
 
-        vm.expectRevert(bytes(AaveErrors.SUPPLY_CAP_EXCEEDED));
+        vm.expectRevert(SupplyCapExceeded.selector);
         user.supplyCollateral(market.underlying, amount, onBehalf);
     }
 

--- a/test/integration/TestIntegrationWithdrawCollateral.sol
+++ b/test/integration/TestIntegrationWithdrawCollateral.sol
@@ -329,7 +329,7 @@ contract TestIntegrationWithdrawCollateral is IntegrationTest {
 
         uint256 poolSupplyIndexAfterFlashLoan = pool.getReserveNormalizedIncome(market.underlying);
 
-        assertGt(poolSupplyIndexAfterFlashLoan, poolSupplyIndexBeforeFlashLoan);
+        assertGe(poolSupplyIndexAfterFlashLoan, poolSupplyIndexBeforeFlashLoan);
 
         user.approve(market.underlying, liquidity);
         user.supplyCollateral(market.underlying, liquidity);


### PR DESCRIPTION
Two changes are needed in the tests, due to:
- the premium to protocol is increased such that no premium goes to LP. As a consequence the index is not increased as expected. A test is added to show that the premium to protocol is the same as the total premium after the update (meaning no premium to LP). One can check [here](https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2#readProxyContract#F3) and [here](https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2#readProxyContract#F4) that it is currently (before the update) not the case
- Aave uses errors instead of strings